### PR TITLE
Assure that the length is an integer

### DIFF
--- a/s2s-ft/s2s_ft/utils.py
+++ b/s2s-ft/s2s_ft/utils.py
@@ -37,7 +37,7 @@ class Seq2seqDatasetForBert(torch.utils.data.Dataset):
         self.span_prob = span_prob
 
     def __len__(self):
-        return self.num_training_instances
+        return int(self.num_training_instances)
 
     def __trunk(self, ids, max_len):
         if len(ids) > max_len - 1:


### PR DESCRIPTION
The current version will cause a bug when using `--num_training_epochs` instead of `--num_training_steps`, because the argument  `num_training_steps` may be a float number here by `args.num_training_steps = args.num_training_epochs * len(training_features) / train_batch_size` Line 113 in `run_seq2seq.py` file.