### PR TITLE
Assure per_node_train_batch_size be non-zero when n_gpu=0

### DIFF
--- a/s2s-ft/run_seq2seq.py
+++ b/s2s-ft/run_seq2seq.py
@@ -105,7 +105,11 @@ def train(args, training_features, model, tokenizer):
     model.to(args.device)
     model, optimizer = prepare_for_training(args, model, checkpoint_state_dict, amp=amp)
 
-    per_node_train_batch_size = args.per_gpu_train_batch_size * args.n_gpu * args.gradient_accumulation_steps
+    if args.n_gpu == 0 or args.no_cuda:
+        per_node_train_batch_size = args.per_gpu_train_batch_size * args.gradient_accumulation_steps
+    else:
+        per_node_train_batch_size = args.per_gpu_train_batch_size * args.n_gpu * args.gradient_accumulation_steps
+        
     train_batch_size = per_node_train_batch_size * (torch.distributed.get_world_size() if args.local_rank != -1 else 1)
     global_step = recover_step if recover_step else 0
 


### PR DESCRIPTION
When using `--no_cuda`, the original script will set  `per_node_train_batch_size` to 0 and thus  `train_batch_size` to 0, and therefore will cause a `division_by_zero` error when doing `int(args.num_training_epochs * len(training_features) / train_batch_size)`