### PR TITLE
Changed tokenizer.max_len attribute to model_max_length

### DIFF
--- a/s2s-ft/decode_seq2seq.py
+++ b/s2s-ft/decode_seq2seq.py
@@ -156,7 +156,7 @@ def main():
     else:
         vocab = tokenizer.vocab
 
-    tokenizer.max_len = args.max_seq_length
+    tokenizer.model_max_length = args.max_seq_length
 
     config_file = args.config_path if args.config_path else os.path.join(args.model_path, "config.json")
     logger.info("Read decoding config from: %s" % config_file)


### PR DESCRIPTION
Transformer(<=v2.0.0)'s tokenizer class (v0.7.0) has certain attributes deprecated. For instance, the max_len attribute has been changed to [model_max_length](https://huggingface.co/transformers/internal/tokenization_utils.html#transformers.tokenization_utils_base.PreTrainedTokenizerBase.max_len). 

Similarly [from_pretrained()](https://huggingface.co/transformers/internal/tokenization_utils.html#transformers.tokenization_utils_base.PreTrainedTokenizerBase.max_len) function of the PreTrainedTokenizerBaseClasss has a deprecated constructor.