### PR TITLE
fix floor division

### DIFF
--- a/s2s-ft/s2s_ft/modeling_decoding.py
+++ b/s2s-ft/s2s_ft/modeling_decoding.py
@@ -1526,7 +1526,7 @@ class BertForSeq2SeqDecoder(PreTrainedBertModel):
                 kk_scores += last_eos * (-10000.0) + last_seq_scores
                 kk_scores = torch.reshape(kk_scores, [batch_size, K * K])
                 k_scores, k_ids = torch.topk(kk_scores, k=K)
-                back_ptrs = torch.floor_division(k_ids, K)
+                back_ptrs = torch.floor_divide(k_ids, K)
                 kk_ids = torch.reshape(kk_ids, [batch_size, K * K])
                 k_ids = torch.gather(kk_ids, 1, k_ids)
             step_back_ptrs.append(back_ptrs)

--- a/s2s-ft/s2s_ft/modeling_decoding.py
+++ b/s2s-ft/s2s_ft/modeling_decoding.py
@@ -1526,7 +1526,7 @@ class BertForSeq2SeqDecoder(PreTrainedBertModel):
                 kk_scores += last_eos * (-10000.0) + last_seq_scores
                 kk_scores = torch.reshape(kk_scores, [batch_size, K * K])
                 k_scores, k_ids = torch.topk(kk_scores, k=K)
-                back_ptrs = torch.div(k_ids, K)
+                back_ptrs = torch.floor_division(k_ids, K)
                 kk_ids = torch.reshape(kk_ids, [batch_size, K * K])
                 k_ids = torch.gather(kk_ids, 1, k_ids)
             step_back_ptrs.append(back_ptrs)


### PR DESCRIPTION
A `RuntimeError: gather_out_cuda(): Expected dtype int64 for index` is raised when running any function that calls `s2s_ft.modeling_decoding.py`, such as `decode_seq2seq.py` #297 .

I traced back the problem to this line

https://github.com/microsoft/unilm/blob/master/s2s-ft/s2s_ft/modeling_decoding.py#L1529

```
back_ptrs = torch.div(k_ids, K)
```
that may return floats whenever `k_ids % K != 0`.

The problem is with `torch.div`. As of version `1.6`, the torch developers decided to make better sense of type upcasting,
and as of version `1.8` they added a parameter `rounding_mode` to `torch.div` let you decide the type of division.

With earlier versions of `torch` (such as `1.6` or `1.7`), `torch.floor_divide` should be used for integer division;
and `torch.div(*args, rounding_mode='floor')` may be used since version `1.8`.

The line needs to be updated with `torch.floor_divide`.