### PR TITLE
fix import on PRESET_MIRROR_DICT

### DIFF
--- a/markuplm/markuplmft/__init__.py
+++ b/markuplm/markuplmft/__init__.py
@@ -1,7 +1,7 @@
 from transformers import CONFIG_MAPPING, MODEL_FOR_QUESTION_ANSWERING_MAPPING, \
     MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING, MODEL_NAMES_MAPPING, TOKENIZER_MAPPING
 from transformers.convert_slow_tokenizer import SLOW_TO_FAST_CONVERTERS, RobertaConverter
-from transformers.file_utils import PRESET_MIRROR_DICT
+# from transformers.file_utils import PRESET_MIRROR_DICT
 
 from .models.markuplm import (
     MarkupLMConfig,


### PR DESCRIPTION
Considering that this variable has not been reused and is incompatible with ‘transformers==4.11.3’ . 

Fix this error:
`ImportError: cannot import name 'PRESET_MIRROR_DICT' from 'transformers.file_utils' (/opt/conda/lib/python3.7/site-packages/transformers/file_utils.py)`