### PR TITLE
Add DiT inference script

### DIFF
--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -41,8 +41,12 @@ def main():
     print(model)
     
     # Step 6: run inference
+    image = torch.rand(1, 3, 512, 512)
+    inputs = {"image": image, "height": height, "width": width}
+    
     with torch.no_grad():
-        outputs = model(torch.rand(1, 3, 512, 512))
+        outputs = model([inputs])
+        print("Outputs:", outputs)
 
 if __name__ == '__main__':
     main()

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -1,11 +1,14 @@
 import argparse
 import torch
+from torchvision.transforms import Compose, ToTensor, Resize, Normalize
 from PIL import Image
 from ditod import add_vit_config
 from detectron2.config import get_cfg
 from detectron2.modeling import build_model
 from detectron2.checkpoint import DetectionCheckpointer
-from torchvision.transforms import Compose, ToTensor, Resize, Normalize
+from detectron2.utils.visualizer import ColorMode, Visualizer
+from detectron2.data.detection_utils import read_image
+
 
 def main():
     parser = argparse.ArgumentParser(description="Detectron2 inference script")
@@ -14,6 +17,11 @@ def main():
         help="Path to input image",
         type=str,
         required=True,
+    )
+    parser.add_argument(
+        "--output",
+        help="Path to save output image",
+        type=str,
     )
     parser.add_argument(
         "--config-file",
@@ -65,6 +73,13 @@ def main():
         print("Outputs:", outputs)
         print(outputs["instances"].pred_classes)
         print(outputs["instances"].pred_boxes)
+
+    # step 7: visualize
+    image = read_image(args.input, format="BGR")
+    metadata = MetadataCatalog.get(cfg.DATASETS.TEST[0] if len(cfg.DATASETS.TEST) else "__unused")
+    visualizer = Visualizer(image, metadata, instance_mode=ColorMode.IMAGE)
+    vis_output = visualizer.draw_instance_predictions(predictions=outputs["instances"])
+    vis_output.save(args.output)
 
 if __name__ == '__main__':
     main()

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -10,6 +10,12 @@ from torchvision.transforms import Compose, ToTensor, Resize, Normalize
 def main():
     parser = argparse.ArgumentParser(description="Detectron2 inference script")
     parser.add_argument(
+        "--input",
+        help="Path to input image",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
         "--config-file",
         default="configs/quick_schedules/mask_rcnn_R_50_FPN_inference_acc_test.yaml",
         metavar="FILE",
@@ -20,10 +26,6 @@ def main():
         help="Modify config options using the command-line 'KEY VALUE' pairs",
         default=[],
         nargs=argparse.REMAINDER,
-    )
-    parser.add_argument(
-        "--input",
-        help="Path to input image",
     )
 
     args = parser.parse_args()

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -1,6 +1,7 @@
 import argparse
+from ditod import add_vit_config
 from detectron2.config import get_cfg
-from detectron2.engine import DefaultPredictor
+from detectron2.modeling import build_model
 
 def main():
     parser = argparse.ArgumentParser(description="Detectron2 inference script")
@@ -19,12 +20,18 @@ def main():
 
     args = parser.parse_args()
 
+    # Step 1: set config
     cfg = get_cfg()
-    # Set config
+    add_vit_config(cfg)
     cfg.merge_from_file(args.config_file)
-    # Set weights using opts argument
+    # Step 2: set model weights
     cfg.merge_from_list(args.opts)
-    predictor = DefaultPredictor(cfg)
+    # Step 3: define model
+    model = build_model(cfg)
+    model.eval()
+    # Step 4: load weights
+    checkpointer = DetectionCheckpointer(model)
+    checkpointer.load(cfg.MODEL.WEIGHTS)
     
     # outputs = predictor(im)
 

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -8,6 +8,7 @@ from detectron2.modeling import build_model
 from detectron2.checkpoint import DetectionCheckpointer
 from detectron2.utils.visualizer import ColorMode, Visualizer
 from detectron2.data.detection_utils import read_image
+from detectron2.data import MetadataCatalog
 
 
 def main():

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -2,6 +2,7 @@ import argparse
 import torch
 from torchvision.transforms import Compose, ToTensor, Resize, Normalize
 from PIL import Image
+import numpy as np
 from ditod import add_vit_config
 from detectron2.config import get_cfg
 from detectron2.modeling import build_model
@@ -47,6 +48,13 @@ def main():
     cfg.merge_from_list(args.opts)
     # Step 3: set device
     cfg.MODEL.DEVICE='cpu'
+
+    print("Image sizes:")
+    print(cfg.INPUT.MIN_SIZE_TRAIN)
+    print(cfg.INPUT.MAX_SIZE_TRAIN)
+    print(cfg.INPUT.MIN_SIZE_TEST)
+    print(cfg.INPUT.MAX_SIZE_TEST)
+
     # Step 4: define model
     model = build_model(cfg)
     model.eval()
@@ -71,14 +79,13 @@ def main():
     
     with torch.no_grad():
         outputs = model([inputs])[0]
-        print("Outputs:", outputs)
         print(outputs["instances"].pred_classes)
         print(outputs["instances"].pred_boxes)
 
     # step 7: visualize
-    image = read_image(args.input, format="BGR")
+    print("Size of image: ", image.size)
     metadata = MetadataCatalog.get(cfg.DATASETS.TEST[0] if len(cfg.DATASETS.TEST) else "__unused")
-    visualizer = Visualizer(image, metadata, instance_mode=ColorMode.IMAGE)
+    visualizer = Visualizer(np.array(image), metadata, instance_mode=ColorMode.IMAGE)
     vis_output = visualizer.draw_instance_predictions(predictions=outputs["instances"])
     vis_output.save(args.output)
 

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -45,7 +45,7 @@ def main():
     inputs = {"image": image, "height": height, "width": width}
     
     with torch.no_grad():
-        outputs = model([inputs])
+        outputs = model(inputs)
         print("Outputs:", outputs)
 
 if __name__ == '__main__':

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -40,12 +40,12 @@ def main():
     print("Weights loaded!")
     
     # Step 6: run inference
-    image = torch.rand(1, 3, 512, 512)
+    image = torch.rand(3, 512, 512)
     height, width = image.shape[-2:]
     inputs = {"image": image, "height": height, "width": width}
     
     with torch.no_grad():
-        outputs = model(inputs)
+        outputs = model([inputs])
         print("Outputs:", outputs)
 
 if __name__ == '__main__':

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -37,11 +37,11 @@ def main():
     checkpointer = DetectionCheckpointer(model)
     checkpointer.load(cfg.MODEL.WEIGHTS)
 
-    print("Weights loaded")
-    print(model)
+    print("Weights loaded!")
     
     # Step 6: run inference
     image = torch.rand(1, 3, 512, 512)
+    height, width = image.shape[-2:]
     inputs = {"image": image, "height": height, "width": width}
     
     with torch.no_grad():

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -1,4 +1,5 @@
 import argparse
+import torch
 from ditod import add_vit_config
 from detectron2.config import get_cfg
 from detectron2.modeling import build_model
@@ -40,7 +41,8 @@ def main():
     print(model)
     
     # Step 6: run inference
-
+    with torch.no_grad():
+        outputs = model(torch.rand(1, 3, 512, 512))
 
 if __name__ == '__main__':
     main()

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -52,7 +52,7 @@ def main():
 
     transforms = Compose([
         Resize((224,224)),
-        ToTensor,
+        ToTensor(),
         Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
     ])
 

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -61,7 +61,7 @@ def main():
     inputs = {"image": pixel_values, "height": height, "width": width}
     
     with torch.no_grad():
-        outputs = model([inputs])
+        outputs = model([inputs])[0]
         print("Outputs:", outputs)
         print(outputs["instances"].pred_classes)
         print(outputs["instances"].pred_boxes)

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -2,6 +2,7 @@ import argparse
 from ditod import add_vit_config
 from detectron2.config import get_cfg
 from detectron2.modeling import build_model
+from detectron2.checkpoint import DetectionCheckpointer
 
 def main():
     parser = argparse.ArgumentParser(description="Detectron2 inference script")

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -26,6 +26,8 @@ def main():
     cfg.merge_from_file(args.config_file)
     # Step 2: set model weights
     cfg.merge_from_list(args.opts)
+    # Step 3: set device
+    cfg.MODEL.DEVICE='cpu'
     # Step 3: define model
     model = build_model(cfg)
     model.eval()

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -25,18 +25,22 @@ def main():
     cfg = get_cfg()
     add_vit_config(cfg)
     cfg.merge_from_file(args.config_file)
-    # Step 2: set model weights
+    # Step 2: add model weights URL to config
     cfg.merge_from_list(args.opts)
     # Step 3: set device
     cfg.MODEL.DEVICE='cpu'
-    # Step 3: define model
+    # Step 4: define model
     model = build_model(cfg)
     model.eval()
-    # Step 4: load weights
+    # Step 5: load weights
     checkpointer = DetectionCheckpointer(model)
     checkpointer.load(cfg.MODEL.WEIGHTS)
+
+    print("Weights loaded")
+    print(model)
     
-    # outputs = predictor(im)
+    # Step 6: run inference
+
 
 if __name__ == '__main__':
     main()

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -1,0 +1,23 @@
+from argparse import ArgumentParser
+from detectron2.config import get_cfg
+from detectron2.engine import DefaultPredictor
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('config', help='Config file')
+    parser.add_argument('opts', help='Additional options, such as model weights')
+
+    args = parser.parse_args()
+
+    cfg = get_cfg()
+    # Set config
+    cfg.merge_from_file(args.config_file)
+    # Set weights using opts argument
+    cfg.merge_from_list(args.opts)
+    predictor = DefaultPredictor(cfg)
+    
+    # outputs = predictor(im)
+
+if __name__ == '__main__':
+    main()
+

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -107,7 +107,7 @@ def main():
         Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
     ])
 
-    resized_image = resize(image, min_size=800, max_size=1333)
+    resized_image = resize(image, size=800, max_size=1333)
     pixel_values = transforms(resized_image)
     print("Shape of pixel values:", pixel_values.shape)
     height, width = pixel_values.shape[-2:]

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -51,7 +51,7 @@ def main():
     transforms = Compose([
         Resize((224,224)),
         ToTensor,
-        Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])),
+        Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
     ])
 
     pixel_values = transforms(image)

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -1,11 +1,21 @@
-from argparse import ArgumentParser
+import argparse
 from detectron2.config import get_cfg
 from detectron2.engine import DefaultPredictor
 
 def main():
-    parser = ArgumentParser()
-    parser.add_argument('config', help='Config file')
-    parser.add_argument('opts', help='Additional options, such as model weights')
+    parser = argparse.ArgumentParser(description="Detectron2 inference script")
+    parser.add_argument(
+        "--config-file",
+        default="configs/quick_schedules/mask_rcnn_R_50_FPN_inference_acc_test.yaml",
+        metavar="FILE",
+        help="path to config file",
+    )
+    parser.add_argument(
+        "--opts",
+        help="Modify config options using the command-line 'KEY VALUE' pairs",
+        default=[],
+        nargs=argparse.REMAINDER,
+    )
 
     args = parser.parse_args()
 

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -62,6 +62,7 @@ def main():
     
     with torch.no_grad():
         outputs = model([inputs])
+        print("Outputs:", outputs)
         print(outputs["instances"].pred_classes)
         print(outputs["instances"].pred_boxes)
 

--- a/dit/object_detection/inference.py
+++ b/dit/object_detection/inference.py
@@ -57,7 +57,7 @@ def main():
     )
     parser.add_argument(
         "--output",
-        help="Path to save output image",
+        help="A file or directory to save output visualizations.",
         type=str,
     )
     parser.add_argument(
@@ -75,28 +75,25 @@ def main():
 
     args = parser.parse_args()
 
-    # Step 1: set config
+    # Step 1: instantiate config
     cfg = get_cfg()
     add_vit_config(cfg)
     cfg.merge_from_file(args.config_file)
+    
     # Step 2: add model weights URL to config
     cfg.merge_from_list(args.opts)
+    
     # Step 3: set device
+    # TODO also support GPU
     cfg.MODEL.DEVICE='cpu'
-
-    print("Image sizes:")
-    print(cfg.INPUT.MIN_SIZE_TRAIN)
-    print(cfg.INPUT.MAX_SIZE_TRAIN)
-    print(cfg.INPUT.MIN_SIZE_TEST)
-    print(cfg.INPUT.MAX_SIZE_TEST)
 
     # Step 4: define model
     model = build_model(cfg)
     model.eval()
+    
     # Step 5: load weights
     checkpointer = DetectionCheckpointer(model)
     checkpointer.load(cfg.MODEL.WEIGHTS)
-
     print("Weights loaded!")
     
     # Step 6: run inference
@@ -109,7 +106,6 @@ def main():
 
     resized_image = resize(image, size=800, max_size=1333)
     pixel_values = transforms(resized_image)
-    print("Shape of pixel values:", pixel_values.shape)
     height, width = pixel_values.shape[-2:]
     inputs = {"image": pixel_values, "height": height, "width": width}
     


### PR DESCRIPTION
This PR aims to add an inference script for DiT object detection. 

=> however, the script doesn't work right now, I'm able to load all weights into the model and run a forward pass (have some questions).

It can be run as follows (after pip installing Detectron2 and timm in Colab):

```
!python /content/unilm/dit/object_detection/inference.py \
--input /content/publaynet_example.jpeg \
--output /content/output \
--config /content/unilm/dit/object_detection/publaynet_configs/maskrcnn/maskrcnn_dit_base.yaml \
--opts MODEL.WEIGHTS https://layoutlm.blob.core.windows.net/dit/dit-fts/publaynet_dit-b_mrcnn.pth \
```

Is it correct that images are resized with `min_size=800` and `max_size=1333` at inference time? Currently, I'm doing this + normalize using the inception mean and standard devation.

cc @lockon-n