### PR TITLE
Pass explicit encoding when opening JSON file

### DIFF
--- a/layoutlmft/layoutlmft/data/datasets/xfun.py
+++ b/layoutlmft/layoutlmft/data/datasets/xfun.py
@@ -103,7 +103,7 @@ class XFUN(datasets.GeneratorBasedBuilder):
     def _generate_examples(self, filepaths):
         for filepath in filepaths:
             logger.info("Generating examples from = %s", filepath)
-            with open(filepath[0], "r") as f:
+            with open(filepath[0], "r", encoding="utf-8") as f:
                 data = json.load(f)
 
             for doc in data["documents"]:


### PR DESCRIPTION
By passing explicit encoding, we make sure there are no issues on Windows machines or wherever the default encoding is not "utf-8".

See issue:
- huggingface/datasets#4099