### PR TITLE
Use cpu by default when loading torch model

### DIFF
--- a/layoutreader/s2s_ft/modeling_decoding.py
+++ b/layoutreader/s2s_ft/modeling_decoding.py
@@ -853,7 +853,7 @@ class PreTrainedBertModel(nn.Module):
         model = cls(config, *inputs, **kwargs)
         if state_dict is None:
             weights_path = os.path.join(pretrained_model_name, WEIGHTS_NAME)
-            state_dict = torch.load(weights_path)
+            state_dict = torch.load(weights_path, map_location='cpu')
 
         old_keys = []
         new_keys = []


### PR DESCRIPTION
We should use cpu by default to load model and then user can move it to GPU if needed.