### PR TITLE
Fix import of collections.Iterable for Python 3.10

### DIFF
--- a/dit/object_detection/ditod/table_evaluation/data_structure.py
+++ b/dit/object_detection/ditod/table_evaluation/data_structure.py
@@ -3,7 +3,10 @@ Data structures used by the evaluation process.
 Yu Fang - March 2019
 """
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import numpy as np
 from shapely.geometry import Polygon

--- a/layoutlmv3/examples/object_detection/ditod/table_evaluation/data_structure.py
+++ b/layoutlmv3/examples/object_detection/ditod/table_evaluation/data_structure.py
@@ -3,7 +3,10 @@ Data structures used by the evaluation process.
 Yu Fang - March 2019
 """
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import numpy as np
 from shapely.geometry import Polygon


### PR DESCRIPTION
It seems that most Python code in the repo imports `Iterable` as such:

```python
try:
    from collections.abc import Iterable
except ImportError:
    from collections import Iterable
```

This commit fixes some imports of `Iterable` to match this style, and makes them compatible with Python 3.10, which moved `Iterable` to `collections.abc`.