### PR TITLE
Two small typos in Beit2 docs

### DIFF
--- a/beit2/README.md
+++ b/beit2/README.md
@@ -27,7 +27,7 @@ alias=`whoami | cut -d'.' -f2`; docker run -it --rm --runtime=nvidia --ipc=host 
 First, clone the repo and install required packages:
 ```
 git clone https://github.com/microsoft/unilm.git
-cd unilm/beitv2
+cd unilm/beit2
 pip install -r requirements.txt
 ```
 

--- a/beit2/semantic_segmentation/README.md
+++ b/beit2/semantic_segmentation/README.md
@@ -17,7 +17,7 @@ cd apex
 pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 ```
 
-3. Follow the guide in [mmseg](https://github.com/open-mmlab/mmsegmentation/blob/master/docs/dataset_prepare.md) to prepare the ADE20k dataset.
+3. Follow the guide in [mmseg](https://github.com/open-mmlab/mmsegmentation/blob/master/docs/en/dataset_prepare.md) to prepare the ADE20k dataset.
 
 
 ## Fine-tuning


### PR DESCRIPTION
1/ directory structure is now unilm/beit2 (not v2)
2/ there is a new url for mmsegmentations' dataset_prepare.md