### PR TITLE
fix(sec): upgrade sphinx to 3.0.4

### DIFF
--- a/decoding/IAD/fairseq/docs/requirements.txt
+++ b/decoding/IAD/fairseq/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx<2.0
+sphinx<3.0.4
 sphinx-argparse

--- a/edgelm/docs/requirements.txt
+++ b/edgelm/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx<2.0
+sphinx<3.0.4
 sphinx-argparse

--- a/infoxlm/fairseq/docs/requirements.txt
+++ b/infoxlm/fairseq/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx<2.0
+sphinx<3.0.4
 sphinx-argparse


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in sphinx 2.0
- [CVE-2020-11022](https://www.oscs1024.com/hd/CVE-2020-11022)


### What did I do？
Upgrade sphinx from 2.0 to 3.0.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>