### PR TITLE
fix(sec): upgrade networkx to 2.6

### DIFF
--- a/markuplm/requirements.txt
+++ b/markuplm/requirements.txt
@@ -6,6 +6,6 @@ transformers[sentencepiece]==4.10.2
 lxml==4.9.1
 absl-py==0.12.0
 tqdm==4.62.3
-networkx==2.3
+networkx==2.6
 tensorboardX==1.8
 bs4==0.0.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in networkx 2.3
- [MPS-2022-15000](https://www.oscs1024.com/hd/MPS-2022-15000)


### What did I do？
Upgrade networkx from 2.3 to 2.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS