### PR TITLE
Update L. 116 of backbone.py

### DIFF
--- a/beats/backbone.py
+++ b/beats/backbone.py
@@ -113,7 +113,7 @@ class TransformerEncoder(nn.Module):
 
         x_conv = self.pos_conv(x.transpose(1, 2))
         x_conv = x_conv.transpose(1, 2)
-        x += x_conv
+        x = x.clone() + x_conv
 
         if not self.layer_norm_first:
             x = self.layer_norm(x)


### PR DESCRIPTION
When fine-tuning the network for our own problem, we encountered the error RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [32, 768, 248]].

This seemed to be triggered by the in place operation occuring L. 116.  To solve this we replaced `x += x_conv` by `x = x.clone() + x_conv`