### PR TITLE
Update README.md Furu Wei URL was not working at the bottom of the document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,4 +250,4 @@ Portions of the source code are based on the [transformers](https://github.com/h
 
 For help or issues using the pre-trained models, please submit a GitHub issue.
 
-For other communications, please contact [Furu Wei](http://gitnlp.org/) (`fuwei@microsoft.com`).
+For other communications, please contact [Furu Wei](https://thegenerality.com) (`fuwei@microsoft.com`).


### PR DESCRIPTION
http://gitnlp.org/ url was not working. Replaced with https://thegenerality.com/