### PR TITLE
Diff Attention out_proj dimension fix

### DIFF
--- a/Diff-Transformer/multihead_diffattn.py
+++ b/Diff-Transformer/multihead_diffattn.py
@@ -52,7 +52,7 @@ class MultiheadDiffAttn(nn.Module):
         self.q_proj = nn.Linear(embed_dim, embed_dim, bias=False)
         self.k_proj = nn.Linear(embed_dim, embed_dim // self.n_rep, bias=False)
         self.v_proj = nn.Linear(embed_dim, embed_dim // self.n_rep, bias=False)
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.out_proj = nn.Linear(self.num_heads * 2 * self.head_dim, embed_dim, bias=False)
 
         self.lambda_init = lambda_init_fn(depth)
         self.lambda_q1 = nn.Parameter(torch.zeros(self.head_dim, dtype=torch.float32).normal_(mean=0,std=0.1))

--- a/Diff-Transformer/multihead_flashdiff_1.py
+++ b/Diff-Transformer/multihead_flashdiff_1.py
@@ -57,7 +57,7 @@ class MultiheadFlashDiff1(nn.Module):
         self.q_proj = nn.Linear(embed_dim, embed_dim, bias=False)
         self.k_proj = nn.Linear(embed_dim, embed_dim // self.n_rep, bias=False)
         self.v_proj = nn.Linear(embed_dim, embed_dim // self.n_rep, bias=False)
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.out_proj = nn.Linear(self.num_heads * 2 * self.head_dim, embed_dim, bias=False)
 
         self.lambda_init = lambda_init_fn(depth)
         self.lambda_q1 = nn.Parameter(torch.zeros(self.head_dim, dtype=torch.float32).normal_(mean=0,std=0.1))

--- a/Diff-Transformer/multihead_flashdiff_2.py
+++ b/Diff-Transformer/multihead_flashdiff_2.py
@@ -56,7 +56,7 @@ class MultiheadFlashDiff2(nn.Module):
         self.q_proj = nn.Linear(embed_dim, embed_dim, bias=False)
         self.k_proj = nn.Linear(embed_dim, embed_dim // self.n_rep, bias=False)
         self.v_proj = nn.Linear(embed_dim, embed_dim // self.n_rep, bias=False)
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.out_proj = nn.Linear(self.num_heads * 2 * self.head_dim, embed_dim, bias=False)
 
         self.lambda_init = lambda_init_fn(depth)
         self.lambda_q1 = nn.Parameter(torch.zeros(self.head_dim, dtype=torch.float32).normal_(mean=0,std=0.1))


### PR DESCRIPTION
Subtle potential issue with `self.out_proj = nn.Linear(embed_dim, embed_dim)` working on `attn.reshape(bsz, tgt_len, self.num_heads * 2 * self.head_dim` in the rare case that `embed_dim != self.num_heads * 2 * self.head_dim`

Small fix in the init of the base and flash attention implementations.