### PR TITLE
Fix xdoc run squad

### DIFF
--- a/xdoc/fine_tuning/squad/requirements.txt
+++ b/xdoc/fine_tuning/squad/requirements.txt
@@ -1,6 +1,7 @@
 sklearn
 transformers==4.23.1
-datasets==2.6.1
+datasets
+evaluate
 numpy==1.21.6
 torch
 IPython

--- a/xdoc/fine_tuning/squad/run_squad.py
+++ b/xdoc/fine_tuning/squad/run_squad.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import datasets
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
+import evaluate
 
 import transformers
 from trainer_qa import QuestionAnsweringTrainer
@@ -571,7 +572,7 @@ def main():
         references = [{"id": ex["id"], "answers": ex[answer_column_name]} for ex in examples]
         return EvalPrediction(predictions=formatted_predictions, label_ids=references)
 
-    metric = load_metric("squad_v2" if data_args.version_2_with_negative else "squad")
+    metric = evaluate.load("squad_v2" if data_args.version_2_with_negative else "squad")
 
     def compute_metrics(p: EvalPrediction):
         return metric.compute(predictions=p.predictions, references=p.label_ids)


### PR DESCRIPTION
Fix `datasets` library usage, introducing the `evaluate` library, and modifying the metric loading function.

Dependency updates:

* [`xdoc/fine_tuning/squad/requirements.txt`](diffhunk://#diff-0a3245c9e4bd31aa15495773438193f5d93bc2f15ef02719c9af1d61692616aaL3-R4): Removed version constraint for `datasets` and added the `evaluate` library.

Code fixes:

* [`xdoc/fine_tuning/squad/run_squad.py`](diffhunk://#diff-91ae11cb380894f0881c3004f51ad56b5552802cba2802ba0c71d91ff86199c4L574-R575): Replaced `load_metric` from `datasets` with `evaluate.load` for loading metrics.