### PR TITLE
Fix ZeroDivisionError in TrOCR scoring metrics

### DIFF
--- a/trocr/scoring.py
+++ b/trocr/scoring.py
@@ -43,6 +43,8 @@ class WPAScorer(BaseScorer):
     def score(self):
 
         length = len(self.refs)
+        if length == 0:
+            return 0.0
         correct = 0
         for i in range(length):
             if self.refs[i] == self.preds[i]:
@@ -71,6 +73,8 @@ class AccEDScorer(BaseScorer):
         self.pred.append(pred)
 
     def score(self):
+        if self.n_data == 0:
+            return 0.0, 0.0
         return self.n_correct / float(self.n_data) * 100, self.ed / float(self.n_data)
 
     def result_string(self):
@@ -98,9 +102,9 @@ class SROIEScorer(BaseScorer):
         self.pred.append(pred)
 
     def score(self):
-        prec = self.n_match_words / float(self.n_detected_words) * 100
-        recall = self.n_match_words / float(self.n_gt_words) * 100
-        f1 = 2 * (prec * recall) / (prec + recall)
+        prec = self.n_match_words / float(self.n_detected_words) * 100 if self.n_detected_words > 0 else 0.0
+        recall = self.n_match_words / float(self.n_gt_words) * 100 if self.n_gt_words > 0 else 0.0
+        f1 = 2 * (prec * recall) / (prec + recall) if (prec + recall) > 0 else 0.0
         return prec, recall, f1
 
     def result_string(self):


### PR DESCRIPTION
## Summary

- Fix `ZeroDivisionError` in `SROIEScorer.score()` when `n_detected_words`, `n_gt_words`, or `prec + recall` is zero
- Fix `ZeroDivisionError` in `WPAScorer.score()` when called with no data added
- Fix `ZeroDivisionError` in `AccEDScorer.score()` when called with no data added

All three scorers in `trocr/scoring.py` can crash with `ZeroDivisionError` on edge cases. For example, `SROIEScorer.score()` divides by `n_detected_words` and `n_gt_words` which are both zero when all predictions or references are empty strings. The F1 computation also divides by `(precision + recall)` which is zero when there are no word matches. This patch adds zero-guards to return `0.0` instead of crashing.

## Test plan

- [x] Verified that scoring with empty predictions no longer crashes
- [x] Verified that normal scoring behavior is unchanged (guards only activate on zero denominators)