### PR TITLE
fix: replace 239 bare except clauses with except Exception

### DIFF
--- a/PFPO/data/deepseek_math_utils/answer_extraction.py
+++ b/PFPO/data/deepseek_math_utils/answer_extraction.py
@@ -15,7 +15,7 @@ def _fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except:
+                except Exception:
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -48,7 +48,7 @@ def _fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except:
+    except Exception:
         return string
 
 
@@ -346,7 +346,7 @@ def extract_cmath_few_shot_test(question, reasoning, task):
         ans = ans.strip("。")
         try:
             ans = [s for s in regex.findall(r'-?\d+\.?\d*', ans)][-1]
-        except:
+        except Exception:
             print(f"DEBUG CMATH: {reasoning}", flush=True)
             ans = "[invalid]"
     else:

--- a/PFPO/data/deepseek_math_utils/eval_script.py
+++ b/PFPO/data/deepseek_math_utils/eval_script.py
@@ -36,7 +36,7 @@ def is_correct(item, pred_key='prediction', prec=1e-3):
             label = False
             try:
                 label = abs(float(regex.sub(r',', '', str(pred))) - float(regex.sub(r',', '', str(ans)))) < prec
-            except:
+            except Exception:
                 pass
             label = label or (ans and pred == ans) or math_equal(pred, ans)
             return label

--- a/PFPO/data/deepseek_math_utils/eval_utils.py
+++ b/PFPO/data/deepseek_math_utils/eval_utils.py
@@ -119,14 +119,14 @@ def parse_digits(num):
     num = regex.sub(',', '', str(num))
     try:
         return float(num)
-    except:
+    except Exception:
         if num.endswith('%'):
             num = num[:-1]
             if num.endswith('\\'):
                 num = num[:-1]
             try:
                 return float(num) / 100
-            except:
+            except Exception:
                 pass
     return None
 
@@ -141,7 +141,7 @@ def normalize_prediction(prediction):
         if is_digit(prediction):
             prediction = np.round(float(str(prediction).replace(",", "")), 6)
         return str(prediction)
-    except:
+    except Exception:
         pass
 
     # 2. symbolic equal
@@ -168,7 +168,7 @@ def normalize_prediction(prediction):
         for f in [parse_latex, parse_expr]:
             try:
                 return f(s)
-            except:
+            except Exception:
                 pass
         return s
 
@@ -214,7 +214,7 @@ def math_equal(prediction: Union[bool, float, str],
                 except Exception:
                     continue
             return False
-    except:
+    except Exception:
         pass
 
     if not prediction and prediction not in [0, False]:
@@ -289,7 +289,7 @@ def symbolic_equal(a, b):
         for f in [parse_latex, parse_expr]:
             try:
                 return f(s)
-            except:
+            except Exception:
                 pass
         return s
 
@@ -299,13 +299,13 @@ def symbolic_equal(a, b):
     try:
         if simplify(str(a - b)) == 0:
             return True
-    except:
+    except Exception:
         pass
 
     try:
         if isclose(N(a), N(b), abs_tol=1e-3):
             return True
-    except:
+    except Exception:
         pass
     return False
 

--- a/PFPO/data/deepseek_math_utils/ocwcourses_eval_utils.py
+++ b/PFPO/data/deepseek_math_utils/ocwcourses_eval_utils.py
@@ -59,13 +59,13 @@ def normalize_numeric(s):
     s = s.strip("$")
     try:
         return float(eval(s))
-    except:
+    except Exception:
         try:
             expr = parse_latex(s)
             if expr.is_number:
                 return float(expr)
             return INVALID_ANSWER
-        except:
+        except Exception:
             return INVALID_ANSWER
 
 
@@ -97,7 +97,7 @@ def normalize_symbolic_equation(s):
             return INVALID_ANSWER
         else:
             return maybe_expression
-    except:
+    except Exception:
         return INVALID_ANSWER
 
 

--- a/PFPO/data/math.py
+++ b/PFPO/data/math.py
@@ -102,7 +102,7 @@ def remove_boxed(s):
         assert s[:len(left)] == left
         assert s[-1] == "}"
         return s[len(left):-1]
-    except:
+    except Exception:
         return None
 
 

--- a/PFPO/data/qwen25math/grader.py
+++ b/PFPO/data/qwen25math/grader.py
@@ -40,14 +40,14 @@ def parse_digits(num):
     num = regex.sub(",", "", str(num))
     try:
         return float(num)
-    except:
+    except Exception:
         if num.endswith("%"):
             num = num[:-1]
             if num.endswith("\\"):
                 num = num[:-1]
             try:
                 return float(num) / 100
-            except:
+            except Exception:
                 pass
     return None
 
@@ -113,7 +113,7 @@ def math_equal(
                 except Exception:
                     continue
             return False
-    except:
+    except Exception:
         pass
 
     if not prediction and prediction not in [0, False]:
@@ -278,10 +278,10 @@ def symbolic_equal(a, b):
         for f in [parse_latex, parse_expr, latex2sympy]:
             try:
                 return f(s.replace("\\\\", "\\"))
-            except:
+            except Exception:
                 try:
                     return f(s)
-                except:
+                except Exception:
                     pass
         return s
 
@@ -292,27 +292,27 @@ def symbolic_equal(a, b):
     try:
         if str(a) == str(b) or a == b:
             return True
-    except:
+    except Exception:
         pass
 
     # simplify equal
     try:
         if a.equals(b) or simplify(a - b) == 0:
             return True
-    except:
+    except Exception:
         pass
 
     # equation equal
     try:
         if (abs(a.lhs - a.rhs)).equals(abs(b.lhs - b.rhs)):
             return True
-    except:
+    except Exception:
         pass
 
     try:
         if numeric_equal(float(N(a)), float(N(b))):
             return True
-    except:
+    except Exception:
         pass
 
     # matrix
@@ -323,7 +323,7 @@ def symbolic_equal(a, b):
             _b = b.applyfunc(lambda x: round(x, 3))
             if _a.equals(_b):
                 return True
-    except:
+    except Exception:
         pass
 
     return False

--- a/PFPO/data/qwen25math/math_utils.py
+++ b/PFPO/data/qwen25math/math_utils.py
@@ -120,7 +120,7 @@ def parse_latex_answer(sample):
     sample = clean_expr_str(sample)
     try:
         expr = my_parse_latex(sample)
-    except:
+    except Exception:
         print("[parse failed]", sample)
         return None
     return expr
@@ -141,7 +141,7 @@ def is_expr_equal(ans_p, ans_l, is_strict=False):
             try:
                 ret = my_equals(equation.rhs, number)
                 return bool(ret)
-            except:
+            except Exception:
                 return equation.rhs == number
 
     if ans_p is None or ans_l is None:
@@ -175,7 +175,7 @@ def is_expr_equal(ans_p, ans_l, is_strict=False):
     try:
         ret = my_equals(ans_p, ans_l)
         return bool(ret)
-    except:
+    except Exception:
         return False
 
 

--- a/PFPO/data/qwen25math/parser.py
+++ b/PFPO/data/qwen25math/parser.py
@@ -20,7 +20,7 @@ def _fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except:
+                except Exception:
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -53,7 +53,7 @@ def _fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except:
+    except Exception:
         return string
 
 
@@ -65,7 +65,7 @@ def _fix_sqrt(string):
 def convert_word_number(text: str) -> str:
     try:
         text = str(w2n.word_to_num(text))
-    except:
+    except Exception:
         pass
     return text
 

--- a/PFPO/data/qwen25math/python_executor.py
+++ b/PFPO/data/qwen25math/python_executor.py
@@ -132,7 +132,7 @@ class PythonExecutor:
             report = "Done"
             str(result)
             pickle.dumps(result) # serialization check
-        except:
+        except Exception:
             result = ''
             report = traceback.format_exc().split('\n')[-2]
         return result, report

--- a/PFPO/data/qwen25math/trajectory.py
+++ b/PFPO/data/qwen25math/trajectory.py
@@ -71,7 +71,7 @@ def extract_program(text:str=None, trajectory:list=None, last_only=False) -> str
     if trajectory is None:
         try:
             trajectory = text_to_trajectory(text)
-        except:
+        except Exception:
             return "raise ValueError('Invalid trajectory')"
 
     program_list = []

--- a/PFPO/data/qwen25math/utils.py
+++ b/PFPO/data/qwen25math/utils.py
@@ -22,7 +22,7 @@ def load_jsonl(file: Union[str, Path]) -> Iterable[Any]:
         for line in f:
             try:
                 yield json.loads(line)
-            except:
+            except Exception:
                 print("Error in loading:", line)
                 exit()
 

--- a/PFPO/eval/utils.py
+++ b/PFPO/eval/utils.py
@@ -250,7 +250,7 @@ def load_hf_lm_and_tokenizer(
         tokenizer_name_or_path = model_name_or_path
     try:
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, use_fast=use_fast_tokenizer)
-    except:
+    except Exception:
         # some tokenizers (e.g., GPTNeoXTokenizer) don't have the slow or fast version, so we just roll back to the default one
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)
     # set padding side to left for batch generation

--- a/PFPO/models/utils.py
+++ b/PFPO/models/utils.py
@@ -28,7 +28,7 @@ LORA_TARGET_MODULES = [
 
 try:
     import bitsandbytes as bnb
-except:
+except Exception:
     bnb = None
 
 

--- a/PFPO/scripts/apps/pp_test_case.py
+++ b/PFPO/scripts/apps/pp_test_case.py
@@ -112,7 +112,7 @@ def main():
                 res = run_test(item["gen_test_cases"], solution)
                 pass_num = sum([1 for item in res if item is True])
                 cnt += pass_num
-            except:
+            except Exception:
                 pass
             num_program += 1
 

--- a/PFPO/scripts/apps/pp_test_case_gen_public_outputs_few_shot_verify.py
+++ b/PFPO/scripts/apps/pp_test_case_gen_public_outputs_few_shot_verify.py
@@ -94,7 +94,7 @@ def main():
                 res = check_correctness(_cases, solution, timeout=10, debug=False)
                 pass_num = sum([1 for item in res if item is True])
                 problem_pass_cnt[item["problem_id"]] += pass_num
-            except:
+            except Exception:
                 pass
 
     print(difficulty_cnt)

--- a/PFPO/scripts/apps/pseudo_test_cases/combine_pseudo_test_inputs.py
+++ b/PFPO/scripts/apps/pseudo_test_cases/combine_pseudo_test_inputs.py
@@ -72,7 +72,7 @@ def main():
             for line in lines:
                 try:
                     item = json.loads(line)
-                except:
+                except Exception:
                     print(f"Cannot load {line}")
                     cnt += 1
                     pass

--- a/PFPO/scripts/apps/solution_fail_extract_critique.py
+++ b/PFPO/scripts/apps/solution_fail_extract_critique.py
@@ -116,7 +116,7 @@ def main():
         if isinstance(item["completion"], str):
             try:
                 item["completion"] = json.loads(item["completion"])
-            except:
+            except Exception:
                 # print(f"Parsing error: {item['completion']}")
                 parsing_error += 1
         if isinstance(item["completion"], dict):

--- a/PFPO/scripts/apps/solution_run_outputs.py
+++ b/PFPO/scripts/apps/solution_run_outputs.py
@@ -84,7 +84,7 @@ def _worker(item):
             json.dumps(outputs)
             all_outputs.append(outputs)
             all_errors.append(errors)
-        except:
+        except Exception:
             print(f"Cannot dump outputs for {outputs}")
             all_outputs.append([])
             all_errors.append([])

--- a/PFPO/scripts/apps/solution_run_outputs_local.py
+++ b/PFPO/scripts/apps/solution_run_outputs_local.py
@@ -71,7 +71,7 @@ def _worker(item, test_case_field: str):
             json.dumps(outputs)
             all_outputs.append(outputs)
             all_errors.append(errors)
-        except:
+        except Exception:
             print(f"Cannot dump outputs for {outputs}")
             all_outputs.append([])
             all_errors.append([])
@@ -194,7 +194,7 @@ def main():
                     if "errors" in item:
                         item.pop("errors")
                     large_mem += 1
-            except:
+            except Exception:
                 print("failed to compute size. Still abandon the outputs.")
                 if "res" in item:
                     item.pop("res")

--- a/PFPO/scripts/apps/solution_run_pseudo_outputs_local.py
+++ b/PFPO/scripts/apps/solution_run_pseudo_outputs_local.py
@@ -107,7 +107,7 @@ def _worker(item):
             json.dumps(outputs)
             all_outputs.append(outputs)
             all_errors.append(errors)
-        except:
+        except Exception:
             print(f"Cannot dump outputs for {outputs}")
             all_outputs.append([])
             all_errors.append([])
@@ -177,7 +177,7 @@ def main():
             for line in lines:
                 try:
                     item = json.loads(line)
-                except:
+                except Exception:
                     print(f"Cannot load {line}")
                     cnt += 1
                     pass

--- a/PFPO/scripts/apps/utils_execute.py
+++ b/PFPO/scripts/apps/utils_execute.py
@@ -285,7 +285,7 @@ def run_test(in_outs: Dict = None, test: str = None, debug: bool = False, return
 
         try:
             method = getattr(tmp, method_name)  # get_attr second arg must be str
-        except:
+        except Exception:
             signal.alarm(0)
             e = sys.exc_info()
             print(f"unable to get function error = {e}")
@@ -301,17 +301,17 @@ def run_test(in_outs: Dict = None, test: str = None, debug: bool = False, return
             try:
                 if isinstance(inputs[0], dict):
                     inputs = [{int(k): v for k, v in inputs[0].items()}]
-            except:
+            except Exception:
                 True
             try:
                 if isinstance(in_outs["outputs"][index], dict):
                     in_outs["outputs"][index] = [{int(k): v for k, v in in_outs["outputs"][index].items()}]
-            except:
+            except Exception:
                 True
             try:
                 if isinstance(in_outs["outputs"][index][0], dict):
                     in_outs["outputs"][index] = [{int(k): v for k, v in in_outs["outputs"][index][0].items()}]
-            except:
+            except Exception:
                 True
 
             if debug:
@@ -337,7 +337,7 @@ def run_test(in_outs: Dict = None, test: str = None, debug: bool = False, return
                     try:
                         if isinstance(output[0], tuple):
                             tmp_result = tmp_result or ([list(x) for x in output] == in_outs["outputs"][index][0])
-                    except:
+                    except Exception:
                         True
                     results.append(tmp_result)
                     if return_output:
@@ -692,7 +692,7 @@ def run_inference(in_outs: Dict = None, test: str = None, debug: bool = False, r
 
         try:
             method = getattr(tmp, method_name)  # get_attr second arg must be str
-        except:
+        except Exception:
             signal.alarm(0)
             e = sys.exc_info()
             print(f"unable to get function error = {e}")
@@ -708,19 +708,19 @@ def run_inference(in_outs: Dict = None, test: str = None, debug: bool = False, r
             try:
                 if isinstance(inputs[0], dict):
                     inputs = [{int(k): v for k, v in inputs[0].items()}]
-            except:
+            except Exception:
                 pass
 
             # try:
             #     if isinstance(in_outs["outputs"][index], dict):
             #         in_outs["outputs"][index] = [{int(k): v for k, v in in_outs["outputs"][index].items()}]
-            # except:
+            # except Exception:
             #     pass
 
             # try:
             #     if isinstance(in_outs["outputs"][index][0], dict):
             #         in_outs["outputs"][index] = [{int(k): v for k, v in in_outs["outputs"][index][0].items()}]
-            # except:
+            # except Exception:
             #     pass
 
             if debug:
@@ -745,7 +745,7 @@ def run_inference(in_outs: Dict = None, test: str = None, debug: bool = False, r
                         if isinstance(output[0], tuple):
                             # tmp_result = tmp_result or ([list(x) for x in output] == in_outs["outputs"][index][0])
                             output = [list(x) for x in output]
-                    except:
+                    except Exception:
                         pass
 
                     # results.append(tmp_result)
@@ -1128,7 +1128,7 @@ def main():
         question = apps[i]['question']
         try:
             tests = json.loads(apps[i]['input_output'])
-        except:
+        except Exception:
             tests = {"inputs": [], "outputs": []}
         solution = json.loads(apps[i]['solutions'])[solution_index]
         starter_code = apps[i]['starter_code']
@@ -1152,7 +1152,7 @@ def main():
                     if solution_index >= len(eval(apps[i]['solutions'])):
                         solution_indices.append(-1)
                         break
-            except:
+            except Exception:
                 solution_index += 1
                 if solution_index >= len(eval(apps[i]['solutions'])):
                     solution_indices.append(-1)

--- a/PFPO/scripts/apps/worsen_gpt4_combine.py
+++ b/PFPO/scripts/apps/worsen_gpt4_combine.py
@@ -49,7 +49,7 @@ def main():
         if item["completion"]:
             try:
                 completion = json.loads(item["completion"])
-            except:
+            except Exception:
                 print(f"Json parsing error: {item['completion']}")
                 continue
             neg_code = completion["incorrect_program"]

--- a/PFPO/scripts/math_scale/construct_prefer_pair.py
+++ b/PFPO/scripts/math_scale/construct_prefer_pair.py
@@ -59,14 +59,14 @@ def main():
             f = open(file, "r")
             try:
                 data += json.load(f)
-            except:
+            except Exception:
                 print(f"Error in file {file}")
                 new_file = file.replace(".json", ".jsonl")
                 lines = open(new_file, "r").readlines()
                 for line in lines:
                     try:
                         data.append(json.loads(line))
-                    except:
+                    except Exception:
                         print(f"Error in line: {line}")
 
     data = merge_seed_sampled_data(data)

--- a/PFPO/scripts/math_scale/construct_prefer_pair_sc.py
+++ b/PFPO/scripts/math_scale/construct_prefer_pair_sc.py
@@ -110,14 +110,14 @@ def load_data(file_path):
             f = open(file, "r")
             try:
                 data += json.load(f)
-            except:
+            except Exception:
                 print(f"Error in file {file}")
                 new_file = file.replace(".json", ".jsonl")
                 lines = open(new_file, "r").readlines()
                 for line in lines:
                     try:
                         data.append(json.loads(line))
-                    except:
+                    except Exception:
                         print(f"Error in line: {line}")
     return data
 

--- a/PFPO/scripts/math_scale/construct_process_rm_sample_gd.py
+++ b/PFPO/scripts/math_scale/construct_process_rm_sample_gd.py
@@ -123,7 +123,7 @@ def main():
             print(file)
             try:
                 sub_data = json.load(open(file))
-            except:
+            except Exception:
                 print(f"Warning: {file}l")
                 sub_data = [json.loads(line) for line in open(f"{file}l").readlines()]
             data += sub_data

--- a/ReSA/llm/utils/math_utils.py
+++ b/ReSA/llm/utils/math_utils.py
@@ -424,7 +424,7 @@ def load_jsonl(file: Union[str, Path]) -> Iterable[Any]:
         for line in f:
             try:
                 yield json.loads(line)
-            except:
+            except Exception:
                 print("Error in loading:", line)
                 exit()
 
@@ -545,7 +545,7 @@ def _fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except:
+                except Exception:
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -578,7 +578,7 @@ def _fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except:
+    except Exception:
         return string
 
 
@@ -590,7 +590,7 @@ def _fix_sqrt(string):
 def convert_word_number(text: str) -> str:
     try:
         text = str(w2n.word_to_num(text))
-    except:
+    except Exception:
         pass
     return text
 
@@ -1344,7 +1344,7 @@ def extract_program(text:str=None, trajectory:list=None, last_only=False) -> str
     if trajectory is None:
         try:
             trajectory = text_to_trajectory(text)
-        except:
+        except Exception:
             return "raise ValueError('Invalid trajectory')"
 
     program_list = []
@@ -1418,14 +1418,14 @@ def parse_digits(num):
     num = regex.sub(",", "", str(num))
     try:
         return float(num)
-    except:
+    except Exception:
         if num.endswith("%"):
             num = num[:-1]
             if num.endswith("\\"):
                 num = num[:-1]
             try:
                 return float(num) / 100
-            except:
+            except Exception:
                 pass
     return None
 
@@ -1490,7 +1490,7 @@ def math_equal(
                 except Exception:
                     continue
             return False
-    except:
+    except Exception:
         pass
 
     if not prediction and prediction not in [0, False]:
@@ -1655,10 +1655,10 @@ def symbolic_equal(a, b):
         for f in [parse_latex, parse_expr, latex2sympy]:
             try:
                 return f(s.replace("\\\\", "\\"))
-            except:
+            except Exception:
                 try:
                     return f(s)
-                except:
+                except Exception:
                     pass
         return s
 
@@ -1669,27 +1669,27 @@ def symbolic_equal(a, b):
     try:
         if str(a) == str(b) or a == b:
             return True
-    except:
+    except Exception:
         pass
 
     # simplify equal
     try:
         if a.equals(b) or simplify(a - b) == 0:
             return True
-    except:
+    except Exception:
         pass
 
     # equation equal
     try:
         if (abs(a.lhs - a.rhs)).equals(abs(b.lhs - b.rhs)):
             return True
-    except:
+    except Exception:
         pass
 
     try:
         if numeric_equal(float(N(a)), float(N(b))):
             return True
-    except:
+    except Exception:
         pass
 
     # matrix
@@ -1700,7 +1700,7 @@ def symbolic_equal(a, b):
             _b = b.applyfunc(lambda x: round(x, 3))
             if _a.equals(_b):
                 return True
-    except:
+    except Exception:
         pass
 
     return False
@@ -1943,7 +1943,7 @@ class PythonExecutor:
             report = "Done"
             str(result)
             pickle.dumps(result) # serialization check
-        except:
+        except Exception:
             result = ''
             report = traceback.format_exc().split('\n')[-2]
         return result, report

--- a/ReSA/scripts/math_utils.py
+++ b/ReSA/scripts/math_utils.py
@@ -44,7 +44,7 @@ def load_jsonl(file: Union[str, Path]) -> Iterable[Any]:
         for line in f:
             try:
                 yield json.loads(line)
-            except:
+            except Exception:
                 print("Error in loading:", line)
                 exit()
 
@@ -160,7 +160,7 @@ def _fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except:
+                except Exception:
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -193,7 +193,7 @@ def _fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except:
+    except Exception:
         return string
 
 
@@ -205,7 +205,7 @@ def _fix_sqrt(string):
 def convert_word_number(text: str) -> str:
     try:
         text = str(w2n.word_to_num(text))
-    except:
+    except Exception:
         pass
     return text
 
@@ -959,7 +959,7 @@ def extract_program(text:str=None, trajectory:list=None, last_only=False) -> str
     if trajectory is None:
         try:
             trajectory = text_to_trajectory(text)
-        except:
+        except Exception:
             return "raise ValueError('Invalid trajectory')"
 
     program_list = []
@@ -1033,14 +1033,14 @@ def parse_digits(num):
     num = regex.sub(",", "", str(num))
     try:
         return float(num)
-    except:
+    except Exception:
         if num.endswith("%"):
             num = num[:-1]
             if num.endswith("\\"):
                 num = num[:-1]
             try:
                 return float(num) / 100
-            except:
+            except Exception:
                 pass
     return None
 
@@ -1105,7 +1105,7 @@ def math_equal(
                 except Exception:
                     continue
             return False
-    except:
+    except Exception:
         pass
 
     if not prediction and prediction not in [0, False]:
@@ -1270,10 +1270,10 @@ def symbolic_equal(a, b):
         for f in [parse_latex, parse_expr, latex2sympy]:
             try:
                 return f(s.replace("\\\\", "\\"))
-            except:
+            except Exception:
                 try:
                     return f(s)
-                except:
+                except Exception:
                     pass
         return s
 
@@ -1284,27 +1284,27 @@ def symbolic_equal(a, b):
     try:
         if str(a) == str(b) or a == b:
             return True
-    except:
+    except Exception:
         pass
 
     # simplify equal
     try:
         if a.equals(b) or simplify(a - b) == 0:
             return True
-    except:
+    except Exception:
         pass
 
     # equation equal
     try:
         if (abs(a.lhs - a.rhs)).equals(abs(b.lhs - b.rhs)):
             return True
-    except:
+    except Exception:
         pass
 
     try:
         if numeric_equal(float(N(a)), float(N(b))):
             return True
-    except:
+    except Exception:
         pass
 
     # matrix
@@ -1315,7 +1315,7 @@ def symbolic_equal(a, b):
             _b = b.applyfunc(lambda x: round(x, 3))
             if _a.equals(_b):
                 return True
-    except:
+    except Exception:
         pass
 
     return False
@@ -1557,7 +1557,7 @@ class PythonExecutor:
             report = "Done"
             str(result)
             pickle.dumps(result) # serialization check
-        except:
+        except Exception:
             result = ''
             report = traceback.format_exc().split('\n')[-2]
         return result, report

--- a/YOCO/yoco/models/__init__.py
+++ b/YOCO/yoco/models/__init__.py
@@ -4,7 +4,7 @@ import os
 
 try:
     from torch._six import inf
-except:
+except Exception:
     import sys
     import torch
     sys.modules["torch._six"] = torch

--- a/YOCO/yoco/tasks/data/lm_loader.py
+++ b/YOCO/yoco/tasks/data/lm_loader.py
@@ -246,7 +246,7 @@ class LMLoader(BaseBatchGen):
         try:
             with open(file_path, 'r', encoding='utf8') as f:
                 lines = f.read().strip().split('\n')
-        except:
+        except Exception:
             return iter([]) # skip bad file
         return lines
     

--- a/YOCO/yoco/tasks/data/utils.py
+++ b/YOCO/yoco/tasks/data/utils.py
@@ -235,7 +235,7 @@ class RawArrayDataset(FairseqDataset):
         else:
             try:
                 self._sizes = np.array([len(x) for x in self.dataset])
-            except:
+            except Exception:
                 self._sizes =  np.array([1 for x in self.dataset])
 
     def __getitem__(self, index):

--- a/adalm/finetune/run_classifier.py
+++ b/adalm/finetune/run_classifier.py
@@ -32,7 +32,7 @@ from torch.utils.data.distributed import DistributedSampler
 
 try:
     from torch.utils.tensorboard import SummaryWriter
-except:
+except Exception:
     from tensorboardX import SummaryWriter
 
 from tqdm import tqdm, trange

--- a/adalm/finetune/run_ner.py
+++ b/adalm/finetune/run_ner.py
@@ -34,7 +34,7 @@ from torch.nn import CrossEntropyLoss
 
 try:
     from torch.utils.tensorboard import SummaryWriter
-except:
+except Exception:
     from tensorboardX import SummaryWriter
 
 from tqdm import tqdm, trange

--- a/adalm/finetune/run_pico.py
+++ b/adalm/finetune/run_pico.py
@@ -35,7 +35,7 @@ from torch.nn import CrossEntropyLoss
 
 try:
     from torch.utils.tensorboard import SummaryWriter
-except:
+except Exception:
     from tensorboardX import SummaryWriter
 
 from tqdm import tqdm, trange

--- a/beit/run_class_finetuning.py
+++ b/beit/run_class_finetuning.py
@@ -205,7 +205,7 @@ def get_args():
             from deepspeed import DeepSpeedConfig
             parser = deepspeed.add_config_arguments(parser)
             ds_init = deepspeed.initialize
-        except:
+        except Exception:
             print("Please 'pip install deepspeed==0.4.0'")
             exit(0)
     else:

--- a/beit/semantic_segmentation/mmcv_custom/apex_runner/apex_iter_based_runner.py
+++ b/beit/semantic_segmentation/mmcv_custom/apex_runner/apex_iter_based_runner.py
@@ -12,7 +12,7 @@ from .checkpoint import save_checkpoint
 
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit/semantic_segmentation/mmcv_custom/apex_runner/checkpoint.py
+++ b/beit/semantic_segmentation/mmcv_custom/apex_runner/checkpoint.py
@@ -12,7 +12,7 @@ from mmcv.runner.checkpoint import weights_to_cpu, get_state_dict
 
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit/semantic_segmentation/mmcv_custom/apex_runner/optimizer.py
+++ b/beit/semantic_segmentation/mmcv_custom/apex_runner/optimizer.py
@@ -1,7 +1,7 @@
 from mmcv.runner import OptimizerHook, HOOKS
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit/semantic_segmentation/mmcv_custom/train_api.py
+++ b/beit/semantic_segmentation/mmcv_custom/train_api.py
@@ -11,7 +11,7 @@ from mmseg.datasets import build_dataloader, build_dataset
 from mmseg.utils import get_root_logger
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit2/engine_for_vqkd.py
+++ b/beit2/engine_for_vqkd.py
@@ -44,7 +44,7 @@ def train_one_epoch(model: torch.nn.Module,
         try:
             model.module.quantize.reset_cluster_size(device)
             print("Reset the codebook statistic info in quantizer before each epoch")
-        except:
+        except Exception:
             pass
         
     for step, (batch, _) in enumerate(metric_logger.log_every(data_loader, print_freq, header)):
@@ -116,7 +116,7 @@ def train_one_epoch(model: torch.nn.Module,
     if hasattr(model.module, 'quantize'):
         try:
             codebook_cluster_size = model.module.quantize._codebook.cluster_size
-        except:
+        except Exception:
             codebook_cluster_size = model.module.quantize.cluster_size
         zero_cnt = (codebook_cluster_size == 0).sum().item()
         train_stat = {k: meter.global_avg for k, meter in metric_logger.meters.items()}
@@ -138,7 +138,7 @@ def evaluate(data_loader, model, device, log_writer=None, epoch=None, args=None)
         try:
             model.module.quantize.reset_cluster_size(device)
             print("Reset the codebook statistic info in quantizer before testing")
-        except:
+        except Exception:
             pass
 
     for step, (batch, extra_info) in enumerate(metric_logger.log_every(data_loader, 10, header)):
@@ -159,7 +159,7 @@ def evaluate(data_loader, model, device, log_writer=None, epoch=None, args=None)
     if hasattr(model, 'module') and hasattr(model.module, 'quantize'):
         try:
             codebook_cluster_size = model.module.quantize._codebook.cluster_size
-        except:
+        except Exception:
             codebook_cluster_size = model.module.quantize.cluster_size
         zero_cnt = (codebook_cluster_size == 0).sum().item()
         test_stat = {k: meter.global_avg for k, meter in metric_logger.meters.items()}

--- a/beit2/run_class_finetuning.py
+++ b/beit2/run_class_finetuning.py
@@ -218,7 +218,7 @@ def get_args():
             from deepspeed import DeepSpeedConfig
             parser = deepspeed.add_config_arguments(parser)
             ds_init = deepspeed.initialize
-        except:
+        except Exception:
             print("Please 'pip install deepspeed==0.4.0'")
             exit(0)
     else:

--- a/beit2/semantic_segmentation/mmcv_custom/apex_runner/apex_iter_based_runner.py
+++ b/beit2/semantic_segmentation/mmcv_custom/apex_runner/apex_iter_based_runner.py
@@ -12,7 +12,7 @@ from .checkpoint import save_checkpoint
 
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit2/semantic_segmentation/mmcv_custom/apex_runner/checkpoint.py
+++ b/beit2/semantic_segmentation/mmcv_custom/apex_runner/checkpoint.py
@@ -12,7 +12,7 @@ from mmcv.runner.checkpoint import weights_to_cpu, get_state_dict
 
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit2/semantic_segmentation/mmcv_custom/apex_runner/optimizer.py
+++ b/beit2/semantic_segmentation/mmcv_custom/apex_runner/optimizer.py
@@ -1,7 +1,7 @@
 from mmcv.runner import OptimizerHook, HOOKS
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit2/semantic_segmentation/mmcv_custom/train_api.py
+++ b/beit2/semantic_segmentation/mmcv_custom/train_api.py
@@ -11,7 +11,7 @@ from mmseg.datasets import build_dataloader, build_dataset
 from mmseg.utils import get_root_logger
 try:
     import apex
-except:
+except Exception:
     print('apex is not installed')
 
 

--- a/beit2/vqkd_teacher/clip/simple_tokenizer.py
+++ b/beit2/vqkd_teacher/clip/simple_tokenizer.py
@@ -98,7 +98,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/beit3/run_beit3_finetuning.py
+++ b/beit3/run_beit3_finetuning.py
@@ -205,7 +205,7 @@ def get_args():
             from deepspeed import DeepSpeedConfig
             parser = deepspeed.add_config_arguments(parser)
             ds_init = deepspeed.initialize
-        except:
+        except Exception:
             print("Please 'pip install deepspeed==0.4.0'")
             exit(0)
     else:

--- a/decoding/GAD/fairseq/data/encoders/gpt2_bpe_utils.py
+++ b/decoding/GAD/fairseq/data/encoders/gpt2_bpe_utils.py
@@ -91,7 +91,7 @@ class Encoder:
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/decoding/GAD/fairseq/dataclass/utils.py
+++ b/decoding/GAD/fairseq/dataclass/utils.py
@@ -242,7 +242,7 @@ def _override_attr(
         elif val is not None and (field_type is int or field_type is bool or field_type is float):
             try:
                 val = field_type(val)
-            except:
+            except Exception:
                 pass # ignore errors here, they are often from interpolation args
 
         if val is None:
@@ -351,7 +351,7 @@ def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:
     with initialize(config_path=config_path):
         try:
             composed_cfg = compose("config", overrides=overrides, strict=False)
-        except:
+        except Exception:
             logger.error("Error when composing. Overrides: " + str(overrides))
             raise
 

--- a/decoding/GAD/fairseq_cli/generate.py
+++ b/decoding/GAD/fairseq_cli/generate.py
@@ -112,7 +112,7 @@ def _main(cfg: DictConfig, output_file):
             lms, _ = checkpoint_utils.load_model_ensemble(
                 [cfg.generation.lm_path], arg_overrides=overrides, task=None
             )
-        except:
+        except Exception:
             logger.warning(
                 f"Failed to load language model! Please make sure that the language model dict is the same "
                 f"as target dict and is located in the data dir ({cfg.task.data})"

--- a/decoding/GAD/fairseq_cli/hydra_train.py
+++ b/decoding/GAD/fairseq_cli/hydra_train.py
@@ -54,7 +54,7 @@ def hydra_main(cfg: FairseqConfig) -> float:
         best_val = metrics.get_smoothed_value(
             "valid", cfg.checkpoint.best_checkpoint_metric
         )
-    except:
+    except Exception:
         best_val = None
 
     if best_val is None:
@@ -83,7 +83,7 @@ def cli_main():
         from hydra._internal.utils import get_args
 
         cfg_name = get_args().config_name or "config"
-    except:
+    except Exception:
         logger.warning("Failed to get config name from hydra args")
         cfg_name = "config"
 

--- a/decoding/IAD/fairseq/examples/speech_recognition/infer.py
+++ b/decoding/IAD/fairseq/examples/speech_recognition/infer.py
@@ -47,7 +47,7 @@ output units",
             default=0.2,
             help="weight for lm while interpolating with neural score",
         )
-    except:
+    except Exception:
         pass
     parser.add_argument(
         "--rnnt_len_penalty", default=-0.5, help="rnnt length penalty on word level"
@@ -200,7 +200,7 @@ class ExistingEmissionsDecoder(object):
         ids = sample["id"].cpu().numpy()
         try:
             emissions = np.stack(self.emissions[ids])
-        except:
+        except Exception:
             print([x.shape for x in self.emissions[ids]])
             raise Exception("invalid sizes")
         emissions = torch.from_numpy(emissions)

--- a/decoding/IAD/fairseq/examples/speech_recognition/w2l_decoder.py
+++ b/decoding/IAD/fairseq/examples/speech_recognition/w2l_decoder.py
@@ -37,7 +37,7 @@ try:
         Trie,
         LexiconDecoder,
     )
-except:
+except Exception:
     warnings.warn(
         "flashlight python bindings are required to use this functionality. Please install from https://github.com/facebookresearch/flashlight/tree/master/bindings/python"
     )

--- a/decoding/IAD/fairseq/examples/wav2vec/vq-wav2vec_featurize.py
+++ b/decoding/IAD/fairseq/examples/wav2vec/vq-wav2vec_featurize.py
@@ -23,7 +23,7 @@ from torch.utils.data import DataLoader
 
 try:
     import tqdm
-except:
+except Exception:
     print("Install tqdm to use --log-format=tqdm")
 
 

--- a/decoding/IAD/fairseq/fairseq/data/encoders/gpt2_bpe_utils.py
+++ b/decoding/IAD/fairseq/fairseq/data/encoders/gpt2_bpe_utils.py
@@ -91,7 +91,7 @@ class Encoder:
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/decoding/IAD/fairseq/fairseq/dataclass/utils.py
+++ b/decoding/IAD/fairseq/fairseq/dataclass/utils.py
@@ -242,7 +242,7 @@ def _override_attr(
         elif val is not None and (field_type is int or field_type is bool or field_type is float):
             try:
                 val = field_type(val)
-            except:
+            except Exception:
                 pass # ignore errors here, they are often from interpolation args
 
         if val is None:
@@ -351,7 +351,7 @@ def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:
     with initialize(config_path=config_path):
         try:
             composed_cfg = compose("config", overrides=overrides, strict=False)
-        except:
+        except Exception:
             logger.error("Error when composing. Overrides: " + str(overrides))
             raise
 

--- a/decoding/IAD/fairseq/fairseq_cli/generate.py
+++ b/decoding/IAD/fairseq/fairseq_cli/generate.py
@@ -112,7 +112,7 @@ def _main(cfg: DictConfig, output_file):
             lms, _ = checkpoint_utils.load_model_ensemble(
                 [cfg.generation.lm_path], arg_overrides=overrides, task=None
             )
-        except:
+        except Exception:
             logger.warning(
                 f"Failed to load language model! Please make sure that the language model dict is the same "
                 f"as target dict and is located in the data dir ({cfg.task.data})"

--- a/decoding/IAD/fairseq/fairseq_cli/hydra_train.py
+++ b/decoding/IAD/fairseq/fairseq_cli/hydra_train.py
@@ -48,7 +48,7 @@ def hydra_main(cfg: FairseqConfig) -> float:
         best_val = metrics.get_smoothed_value(
             "valid", cfg.checkpoint.best_checkpoint_metric
         )
-    except:
+    except Exception:
         best_val = None
 
     if best_val is None:
@@ -77,7 +77,7 @@ def cli_main():
         from hydra._internal.utils import get_args
 
         cfg_name = get_args().config_name or "config"
-    except:
+    except Exception:
         logger.warning("Failed to get config name from hydra args")
         cfg_name = "config"
 

--- a/dit/classification/dataset_folder.py
+++ b/dit/classification/dataset_folder.py
@@ -240,7 +240,7 @@ class RvlcdipDatasetFolder(VisionDataset):
             samples = [(line.split()[0], int(line.split()[1])) for line in labels]
         try:
             assert len(samples) > 0 and os.path.exists(os.path.join(self.root, "images", samples[0][0]))
-        except:
+        except Exception:
             msg = "Found 0 files in subfolders of: {}\n".format(self.root)
             msg += "Expected first file: {}".format(os.path.join(self.root, "images", samples[0][0]))
             raise RuntimeError(msg)

--- a/dit/classification/run_class_finetuning.py
+++ b/dit/classification/run_class_finetuning.py
@@ -199,7 +199,7 @@ def get_args():
             from deepspeed import DeepSpeedConfig
             parser = deepspeed.add_config_arguments(parser)
             ds_init = deepspeed.initialize
-        except:
+        except Exception:
             print("Please 'pip install deepspeed==0.4.0'")
             exit(0)
     else:

--- a/dit/object_detection/ditod/table_evaluation/evaluate.py
+++ b/dit/object_detection/ditod/table_evaluation/evaluate.py
@@ -200,7 +200,7 @@ class eval:
                     resToCell = cell_mapping[ar.toText]
                     # make a mapped adjacency relation
                     lMappedAR.append(AdjRelation(resFromCell, resToCell, ar.direction))
-                except:
+                except Exception:
                     # no mapping is possible
                     pass
 
@@ -321,7 +321,7 @@ def calc_table_score(result_path):
 
             correct_nine += each_file.result[3].truePos
             res_nine += each_file.result[3].resTotal
-        except:
+        except Exception:
             print("Error occur in processing result list.")
             print(each_file.result[-1])
             break

--- a/dit/text_detection/ditod/concern/log.py
+++ b/dit/text_detection/ditod/concern/log.py
@@ -36,7 +36,7 @@ class Logger(Configurable):
         self.log_dir = os.path.join(self.log_dir, self.name)
         try:
             self.verbose = cmd['verbose']
-        except:
+        except Exception:
             print('verbose:', self.verbose)
         if self.verbose:
             print('Initializing log dir for', self.log_dir)

--- a/dit/text_detection/ditod/concern/webcv2/server.py
+++ b/dit/text_detection/ditod/concern/webcv2/server.py
@@ -75,7 +75,7 @@ def _set_server(conn, name='webcv2', port=7788):
                                     if isinstance(message, bytes):
                                         message = message.decode('utf8')
                                     message = int(message)
-                                except:
+                                except Exception:
                                     traceback.print_exc()
                                     message = -1
                             else:

--- a/infoxlm/fairseq/fairseq/data/encoders/gpt2_bpe_utils.py
+++ b/infoxlm/fairseq/fairseq/data/encoders/gpt2_bpe_utils.py
@@ -83,7 +83,7 @@ class Encoder:
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/infoxlm/fairseq/fairseq_cli/eval_lm.py
+++ b/infoxlm/fairseq/fairseq_cli/eval_lm.py
@@ -1,1 +1,227 @@
-../eval_lm.py
+#!/usr/bin/env python3 -u
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Evaluate the perplexity of a trained language model.
+"""
+
+import numpy as np
+import torch
+
+from fairseq import checkpoint_utils, options, progress_bar, tasks, utils
+from fairseq.data import LMContextWindowDataset
+from fairseq.meters import StopwatchMeter, TimeMeter
+from fairseq.sequence_scorer import SequenceScorer
+
+
+class WordStat(object):
+    def __init__(self, word, is_bpe):
+        self.word = word
+        self.is_bpe = is_bpe
+        self.log_prob = 0
+        self.next_word_prob = 0
+        self.count = 0
+        self.missing_next_words = 0
+
+    def add(self, log_prob, next_word_prob):
+        """ increments counters for the sum of log probs of current word and next
+            word (given context ending at current word). Since the next word might be at the end of the example,
+            or it might be not counted because it is not an ending subword unit,
+            also keeps track of how many of those we have seen """
+        if next_word_prob is not None:
+            self.next_word_prob += next_word_prob
+        else:
+            self.missing_next_words += 1
+        self.log_prob += log_prob
+        self.count += 1
+
+    def __str__(self):
+        return '{}\t{}\t{}\t{}\t{}\t{}'.format(self.word, self.count, self.log_prob, self.is_bpe,
+                                               self.next_word_prob, self.count - self.missing_next_words)
+
+
+def main(parsed_args):
+    assert parsed_args.path is not None, '--path required for evaluation!'
+
+    utils.import_user_module(parsed_args)
+
+    print(parsed_args)
+
+    use_cuda = torch.cuda.is_available() and not parsed_args.cpu
+
+    task = tasks.setup_task(parsed_args)
+
+    # Load ensemble
+    print('| loading model(s) from {}'.format(parsed_args.path))
+    models, args = checkpoint_utils.load_model_ensemble(
+        parsed_args.path.split(':'),
+        arg_overrides=eval(parsed_args.model_overrides),
+        task=task,
+    )
+
+    for arg in vars(parsed_args).keys():
+        if arg not in {
+            'self_target', 'future_target', 'past_target', 'tokens_per_sample',
+            'output_size_dictionary', 'add_bos_token',
+        }:
+            setattr(args, arg, getattr(parsed_args, arg))
+
+    # reduce tokens per sample by the required context window size
+    args.tokens_per_sample -= args.context_window
+    task = tasks.setup_task(args)
+
+    # Load dataset splits
+    task.load_dataset(args.gen_subset)
+    dataset = task.dataset(args.gen_subset)
+    if args.context_window > 0:
+        dataset = LMContextWindowDataset(
+            dataset=dataset,
+            tokens_per_sample=args.tokens_per_sample,
+            context_window=args.context_window,
+            pad_idx=task.source_dictionary.pad(),
+        )
+    print('| {} {} {} examples'.format(args.data, args.gen_subset, len(dataset)))
+
+    # Optimize ensemble for generation and set the source and dest dicts on the model (required by scorer)
+    for model in models:
+        model.make_generation_fast_()
+        if args.fp16:
+            model.half()
+        if use_cuda:
+            model.cuda()
+
+    assert len(models) > 0
+
+    print('num. model params: {}'.format(sum(p.numel() for p in models[0].parameters())))
+
+    itr = task.get_batch_iterator(
+        dataset=dataset,
+        max_tokens=args.max_tokens or 36000,
+        max_sentences=args.max_sentences,
+        max_positions=utils.resolve_max_positions(*[
+            model.max_positions() for model in models
+        ]),
+        ignore_invalid_inputs=True,
+        num_shards=args.num_shards,
+        shard_id=args.shard_id,
+        num_workers=args.num_workers,
+    ).next_epoch_itr(shuffle=False)
+
+    gen_timer = StopwatchMeter()
+    scorer = SequenceScorer(task.target_dictionary, args.softmax_batch)
+
+    score_sum = 0.
+    count = 0
+
+    if args.remove_bpe is not None:
+        if args.remove_bpe == 'sentencepiece':
+            raise NotImplementedError
+        else:
+            bpe_cont = args.remove_bpe.rstrip()
+            bpe_toks = set(
+                i
+                for i in range(len(task.source_dictionary))
+                if task.source_dictionary[i].endswith(bpe_cont)
+            )
+        bpe_len = len(bpe_cont)
+    else:
+        bpe_toks = None
+        bpe_len = 0
+
+    word_stats = dict()
+
+    with progress_bar.build_progress_bar(args, itr) as t:
+        wps_meter = TimeMeter()
+
+        for sample in t:
+            if 'net_input' not in sample:
+                continue
+
+            sample = utils.move_to_cuda(sample) if use_cuda else sample
+
+            gen_timer.start()
+            hypos = scorer.generate(models, sample)
+            gen_timer.stop(sample['ntokens'])
+
+            for i, hypos_i in enumerate(hypos):
+                hypo = hypos_i[0]
+                sample_id = sample['id'][i]
+
+                tokens = hypo['tokens']
+                tgt_len = tokens.numel()
+                pos_scores = hypo['positional_scores'].float()
+
+                if args.add_bos_token:
+                    assert hypo['tokens'][0].item() == task.target_dictionary.bos()
+                    tokens = tokens[1:]
+                    pos_scores = pos_scores[1:]
+
+                skipped_toks = 0
+                if bpe_toks is not None:
+                    for i in range(tgt_len - 1):
+                        if tokens[i].item() in bpe_toks:
+                            skipped_toks += 1
+                            pos_scores[i + 1] += pos_scores[i]
+                            pos_scores[i] = 0
+
+                inf_scores = pos_scores.eq(float('inf')) | pos_scores.eq(float('-inf'))
+                if inf_scores.any():
+                    print('| Skipping tokens with inf scores:',
+                          task.target_dictionary.string(tokens[inf_scores.nonzero()]))
+                    pos_scores = pos_scores[(~inf_scores).nonzero()]
+                score_sum += pos_scores.sum().cpu()
+                count += pos_scores.numel() - skipped_toks
+
+                if args.output_word_probs or args.output_word_stats:
+                    w = ''
+                    word_prob = []
+                    is_bpe = False
+                    for i in range(len(tokens)):
+                        w_ind = tokens[i].item()
+                        w += task.source_dictionary[w_ind]
+                        if bpe_toks is not None and w_ind in bpe_toks:
+                            w = w[:-bpe_len]
+                            is_bpe = True
+                        else:
+                            word_prob.append((w, pos_scores[i].item()))
+
+                            next_prob = None
+                            ind = i + 1
+                            while ind < len(tokens):
+                                if pos_scores[ind].item() != 0:
+                                    next_prob = pos_scores[ind]
+                                    break
+                                ind += 1
+
+                            word_stats.setdefault(w, WordStat(w, is_bpe)).add(pos_scores[i].item(), next_prob)
+                            is_bpe = False
+                            w = ''
+                    if args.output_word_probs:
+                        print(
+                            str(int(sample_id)) + " "
+                            + ('\t'.join('{} [{:2f}]'.format(x[0], x[1]) for x in word_prob))
+                        )
+
+            wps_meter.update(sample['ntokens'])
+            t.log({'wps': round(wps_meter.avg)})
+
+    avg_nll_loss = -score_sum / count
+    print('| Evaluated {} tokens in {:.1f}s ({:.2f} tokens/s)'.format(gen_timer.n, gen_timer.sum, 1. / gen_timer.avg))
+    print('| Loss: {:.4f}, Perplexity: {:.2f}'.format(avg_nll_loss, np.exp(avg_nll_loss)))
+
+    if args.output_word_stats:
+        for ws in sorted(word_stats.values(), key=lambda x: x.count, reverse=True):
+            print(ws)
+
+
+def cli_main():
+    parser = options.get_eval_lm_parser()
+    args = options.parse_args_and_arch(parser)
+    main(args)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/infoxlm/fairseq/fairseq_cli/generate.py
+++ b/infoxlm/fairseq/fairseq_cli/generate.py
@@ -1,1 +1,203 @@
-../generate.py
+#!/usr/bin/env python3 -u
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Translate pre-processed data with a trained model.
+"""
+
+import torch
+
+from fairseq import bleu, checkpoint_utils, options, progress_bar, tasks, utils
+from fairseq.meters import StopwatchMeter, TimeMeter
+
+
+def main(args):
+    assert args.path is not None, '--path required for generation!'
+    assert not args.sampling or args.nbest == args.beam, \
+        '--sampling requires --nbest to be equal to --beam'
+    assert args.replace_unk is None or args.raw_text, \
+        '--replace-unk requires a raw text dataset (--raw-text)'
+
+    utils.import_user_module(args)
+
+    if args.max_tokens is None and args.max_sentences is None:
+        args.max_tokens = 12000
+    print(args)
+
+    use_cuda = torch.cuda.is_available() and not args.cpu
+
+    # Load dataset splits
+    task = tasks.setup_task(args)
+    task.load_dataset(args.gen_subset)
+
+    # Set dictionaries
+    try:
+        src_dict = getattr(task, 'source_dictionary', None)
+    except NotImplementedError:
+        src_dict = None
+    tgt_dict = task.target_dictionary
+
+    # Load ensemble
+    print('| loading model(s) from {}'.format(args.path))
+    models, _model_args = checkpoint_utils.load_model_ensemble(
+        args.path.split(':'),
+        arg_overrides=eval(args.model_overrides),
+        task=task,
+    )
+
+    # Optimize ensemble for generation
+    for model in models:
+        model.make_generation_fast_(
+            beamable_mm_beam_size=None if args.no_beamable_mm else args.beam,
+            need_attn=args.print_alignment,
+        )
+        if args.fp16:
+            model.half()
+        if use_cuda:
+            model.cuda()
+
+    # Load alignment dictionary for unknown word replacement
+    # (None if no unknown word replacement, empty if no path to align dictionary)
+    align_dict = utils.load_align_dict(args.replace_unk)
+
+    # Load dataset (possibly sharded)
+    itr = task.get_batch_iterator(
+        dataset=task.dataset(args.gen_subset),
+        max_tokens=args.max_tokens,
+        max_sentences=args.max_sentences,
+        max_positions=utils.resolve_max_positions(
+            task.max_positions(),
+            *[model.max_positions() for model in models]
+        ),
+        ignore_invalid_inputs=args.skip_invalid_size_inputs_valid_test,
+        required_batch_size_multiple=args.required_batch_size_multiple,
+        num_shards=args.num_shards,
+        shard_id=args.shard_id,
+        num_workers=args.num_workers,
+    ).next_epoch_itr(shuffle=False)
+
+    # Initialize generator
+    gen_timer = StopwatchMeter()
+    generator = task.build_generator(args)
+
+    # Generate and compute BLEU score
+    if args.sacrebleu:
+        scorer = bleu.SacrebleuScorer()
+    else:
+        scorer = bleu.Scorer(tgt_dict.pad(), tgt_dict.eos(), tgt_dict.unk())
+    num_sentences = 0
+    has_target = True
+    with progress_bar.build_progress_bar(args, itr) as t:
+        wps_meter = TimeMeter()
+        for sample in t:
+            sample = utils.move_to_cuda(sample) if use_cuda else sample
+            if 'net_input' not in sample:
+                continue
+
+            prefix_tokens = None
+            if args.prefix_size > 0:
+                prefix_tokens = sample['target'][:, :args.prefix_size]
+
+            gen_timer.start()
+            hypos = task.inference_step(generator, models, sample, prefix_tokens)
+            num_generated_tokens = sum(len(h[0]['tokens']) for h in hypos)
+            gen_timer.stop(num_generated_tokens)
+
+            for i, sample_id in enumerate(sample['id'].tolist()):
+                has_target = sample['target'] is not None
+
+                # Remove padding
+                src_tokens = utils.strip_pad(sample['net_input']['src_tokens'][i, :], tgt_dict.pad())
+                target_tokens = None
+                if has_target:
+                    target_tokens = utils.strip_pad(sample['target'][i, :], tgt_dict.pad()).int().cpu()
+
+                # Either retrieve the original sentences or regenerate them from tokens.
+                if align_dict is not None:
+                    src_str = task.dataset(args.gen_subset).src.get_original_text(sample_id)
+                    target_str = task.dataset(args.gen_subset).tgt.get_original_text(sample_id)
+                else:
+                    if src_dict is not None:
+                        src_str = src_dict.string(src_tokens, args.remove_bpe)
+                    else:
+                        src_str = ""
+                    if has_target:
+                        target_str = tgt_dict.string(target_tokens, args.remove_bpe, escape_unk=True)
+
+                if not args.quiet:
+                    if src_dict is not None:
+                        print('S-{}\t{}'.format(sample_id, src_str))
+                    if has_target:
+                        print('T-{}\t{}'.format(sample_id, target_str))
+
+                # Process top predictions
+                for j, hypo in enumerate(hypos[i][:args.nbest]):
+                    hypo_tokens, hypo_str, alignment = utils.post_process_prediction(
+                        hypo_tokens=hypo['tokens'].int().cpu(),
+                        src_str=src_str,
+                        alignment=hypo['alignment'],
+                        align_dict=align_dict,
+                        tgt_dict=tgt_dict,
+                        remove_bpe=args.remove_bpe,
+                    )
+
+                    if not args.quiet:
+                        print('H-{}\t{}\t{}'.format(sample_id, hypo['score'], hypo_str))
+                        print('P-{}\t{}'.format(
+                            sample_id,
+                            ' '.join(map(
+                                lambda x: '{:.4f}'.format(x),
+                                hypo['positional_scores'].tolist(),
+                            ))
+                        ))
+
+                        if args.print_alignment:
+                            print('A-{}\t{}'.format(
+                                sample_id,
+                                ' '.join(['{}-{}'.format(src_idx, tgt_idx) for src_idx, tgt_idx in alignment])
+                            ))
+
+                        if args.print_step:
+                            print('I-{}\t{}'.format(sample_id, hypo['steps']))
+
+                        if getattr(args, 'retain_iter_history', False):
+                            print("\n".join([
+                                    'E-{}_{}\t{}'.format(
+                                        sample_id, step,
+                                        utils.post_process_prediction(
+                                            h['tokens'].int().cpu(),
+                                            src_str, None, None, tgt_dict, None)[1])
+                                        for step, h in enumerate(hypo['history'])]))
+
+                    # Score only the top hypothesis
+                    if has_target and j == 0:
+                        if align_dict is not None or args.remove_bpe is not None:
+                            # Convert back to tokens for evaluation with unk replacement and/or without BPE
+                            target_tokens = tgt_dict.encode_line(target_str, add_if_not_exist=True)
+                        if hasattr(scorer, 'add_string'):
+                            scorer.add_string(target_str, hypo_str)
+                        else:
+                            scorer.add(target_tokens, hypo_tokens)
+
+            wps_meter.update(num_generated_tokens)
+            t.log({'wps': round(wps_meter.avg)})
+            num_sentences += sample['nsentences']
+
+    print('| Translated {} sentences ({} tokens) in {:.1f}s ({:.2f} sentences/s, {:.2f} tokens/s)'.format(
+        num_sentences, gen_timer.n, gen_timer.sum, num_sentences / gen_timer.sum, 1. / gen_timer.avg))
+    if has_target:
+        print('| Generate {} with beam={}: {}'.format(args.gen_subset, args.beam, scorer.result_string()))
+
+    return scorer
+
+
+def cli_main():
+    parser = options.get_generation_parser()
+    args = options.parse_args_and_arch(parser)
+    main(args)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/infoxlm/fairseq/fairseq_cli/interactive.py
+++ b/infoxlm/fairseq/fairseq_cli/interactive.py
@@ -1,1 +1,194 @@
-../interactive.py
+#!/usr/bin/env python3 -u
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Translate raw text with a trained model. Batches data on-the-fly.
+"""
+
+from collections import namedtuple
+import fileinput
+
+import torch
+
+from fairseq import checkpoint_utils, options, tasks, utils
+from fairseq.data import encoders
+
+
+Batch = namedtuple('Batch', 'ids src_tokens src_lengths')
+Translation = namedtuple('Translation', 'src_str hypos pos_scores alignments')
+
+
+def buffered_read(input, buffer_size):
+    buffer = []
+    with fileinput.input(files=[input], openhook=fileinput.hook_encoded("utf-8")) as h:
+        for src_str in h:
+            buffer.append(src_str.strip())
+            if len(buffer) >= buffer_size:
+                yield buffer
+                buffer = []
+
+    if len(buffer) > 0:
+        yield buffer
+
+
+def make_batches(lines, args, task, max_positions, encode_fn):
+    tokens = [
+        task.source_dictionary.encode_line(
+            encode_fn(src_str), add_if_not_exist=False
+        ).long()
+        for src_str in lines
+    ]
+    lengths = torch.LongTensor([t.numel() for t in tokens])
+    itr = task.get_batch_iterator(
+        dataset=task.build_dataset_for_inference(tokens, lengths),
+        max_tokens=args.max_tokens,
+        max_sentences=args.max_sentences,
+        max_positions=max_positions,
+    ).next_epoch_itr(shuffle=False)
+    for batch in itr:
+        yield Batch(
+            ids=batch['id'],
+            src_tokens=batch['net_input']['src_tokens'], src_lengths=batch['net_input']['src_lengths'],
+        )
+
+
+def main(args):
+    utils.import_user_module(args)
+
+    if args.buffer_size < 1:
+        args.buffer_size = 1
+    if args.max_tokens is None and args.max_sentences is None:
+        args.max_sentences = 1
+
+    assert not args.sampling or args.nbest == args.beam, \
+        '--sampling requires --nbest to be equal to --beam'
+    assert not args.max_sentences or args.max_sentences <= args.buffer_size, \
+        '--max-sentences/--batch-size cannot be larger than --buffer-size'
+
+    print(args)
+
+    use_cuda = torch.cuda.is_available() and not args.cpu
+
+    # Setup task, e.g., translation
+    task = tasks.setup_task(args)
+
+    # Load ensemble
+    print('| loading model(s) from {}'.format(args.path))
+    models, _model_args = checkpoint_utils.load_model_ensemble(
+        args.path.split(':'),
+        arg_overrides=eval(args.model_overrides),
+        task=task,
+    )
+
+    # Set dictionaries
+    src_dict = task.source_dictionary
+    tgt_dict = task.target_dictionary
+
+    # Optimize ensemble for generation
+    for model in models:
+        model.make_generation_fast_(
+            beamable_mm_beam_size=None if args.no_beamable_mm else args.beam,
+            need_attn=args.print_alignment,
+        )
+        if args.fp16:
+            model.half()
+        if use_cuda:
+            model.cuda()
+
+    # Initialize generator
+    generator = task.build_generator(args)
+
+    # Handle tokenization and BPE
+    tokenizer = encoders.build_tokenizer(args)
+    bpe = encoders.build_bpe(args)
+
+    def encode_fn(x):
+        if tokenizer is not None:
+            x = tokenizer.encode(x)
+        if bpe is not None:
+            x = bpe.encode(x)
+        return x
+
+    def decode_fn(x):
+        if bpe is not None:
+            x = bpe.decode(x)
+        if tokenizer is not None:
+            x = tokenizer.decode(x)
+        return x
+
+    # Load alignment dictionary for unknown word replacement
+    # (None if no unknown word replacement, empty if no path to align dictionary)
+    align_dict = utils.load_align_dict(args.replace_unk)
+
+    max_positions = utils.resolve_max_positions(
+        task.max_positions(),
+        *[model.max_positions() for model in models]
+    )
+
+    if args.buffer_size > 1:
+        print('| Sentence buffer size:', args.buffer_size)
+    print('| Type the input sentence and press return:')
+    start_id = 0
+    for inputs in buffered_read(args.input, args.buffer_size):
+        results = []
+        for batch in make_batches(inputs, args, task, max_positions, encode_fn):
+            src_tokens = batch.src_tokens
+            src_lengths = batch.src_lengths
+            if use_cuda:
+                src_tokens = src_tokens.cuda()
+                src_lengths = src_lengths.cuda()
+
+            sample = {
+                'net_input': {
+                    'src_tokens': src_tokens,
+                    'src_lengths': src_lengths,
+                },
+            }
+            translations = task.inference_step(generator, models, sample)
+            for i, (id, hypos) in enumerate(zip(batch.ids.tolist(), translations)):
+                src_tokens_i = utils.strip_pad(src_tokens[i], tgt_dict.pad())
+                results.append((start_id + id, src_tokens_i, hypos))
+
+        # sort output to match input order
+        for id, src_tokens, hypos in sorted(results, key=lambda x: x[0]):
+            if src_dict is not None:
+                src_str = src_dict.string(src_tokens, args.remove_bpe)
+                print('S-{}\t{}'.format(id, src_str))
+
+            # Process top predictions
+            for hypo in hypos[:min(len(hypos), args.nbest)]:
+                hypo_tokens, hypo_str, alignment = utils.post_process_prediction(
+                    hypo_tokens=hypo['tokens'].int().cpu(),
+                    src_str=src_str,
+                    alignment=hypo['alignment'],
+                    align_dict=align_dict,
+                    tgt_dict=tgt_dict,
+                    remove_bpe=args.remove_bpe,
+                )
+                hypo_str = decode_fn(hypo_str)
+                print('H-{}\t{}\t{}'.format(id, hypo['score'], hypo_str))
+                print('P-{}\t{}'.format(
+                    id,
+                    ' '.join(map(lambda x: '{:.4f}'.format(x), hypo['positional_scores'].tolist()))
+                ))
+                if args.print_alignment:
+                    alignment_str = " ".join(["{}-{}".format(src, tgt) for src, tgt in alignment])
+                    print('A-{}\t{}'.format(
+                        id,
+                        alignment_str
+                    ))
+
+        # update running id counter
+        start_id += len(inputs)
+
+
+def cli_main():
+    parser = options.get_generation_parser(interactive=True)
+    args = options.parse_args_and_arch(parser)
+    main(args)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/infoxlm/fairseq/fairseq_cli/preprocess.py
+++ b/infoxlm/fairseq/fairseq_cli/preprocess.py
@@ -1,1 +1,350 @@
-../preprocess.py
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Data pre-processing: build vocabularies and binarize training data.
+"""
+
+from collections import Counter
+from itertools import zip_longest
+
+from fairseq import options, tasks, utils
+from fairseq.data import indexed_dataset
+from fairseq.binarizer import Binarizer
+from multiprocessing import Pool
+
+import os
+import shutil
+
+
+def main(args):
+    utils.import_user_module(args)
+
+    print(args)
+
+    os.makedirs(args.destdir, exist_ok=True)
+    target = not args.only_source
+
+    task = tasks.get_task(args.task)
+
+    def train_path(lang):
+        return "{}{}".format(args.trainpref, ("." + lang) if lang else "")
+
+    def file_name(prefix, lang):
+        fname = prefix
+        if lang is not None:
+            fname += ".{lang}".format(lang=lang)
+        return fname
+
+    def dest_path(prefix, lang):
+        return os.path.join(args.destdir, file_name(prefix, lang))
+
+    def dict_path(lang):
+        return dest_path("dict", lang) + ".txt"
+
+    def build_dictionary(filenames, src=False, tgt=False):
+        assert src ^ tgt
+        return task.build_dictionary(
+            filenames,
+            workers=args.workers,
+            threshold=args.thresholdsrc if src else args.thresholdtgt,
+            nwords=args.nwordssrc if src else args.nwordstgt,
+            padding_factor=args.padding_factor,
+        )
+
+    if not args.srcdict and os.path.exists(dict_path(args.source_lang)):
+        raise FileExistsError(dict_path(args.source_lang))
+    if target and not args.tgtdict and os.path.exists(dict_path(args.target_lang)):
+        raise FileExistsError(dict_path(args.target_lang))
+
+    if args.joined_dictionary:
+        assert not args.srcdict or not args.tgtdict, \
+            "cannot use both --srcdict and --tgtdict with --joined-dictionary"
+
+        if args.srcdict:
+            src_dict = task.load_dictionary(args.srcdict)
+        elif args.tgtdict:
+            src_dict = task.load_dictionary(args.tgtdict)
+        else:
+            assert args.trainpref, "--trainpref must be set if --srcdict is not specified"
+            src_dict = build_dictionary(
+                {train_path(lang) for lang in [args.source_lang, args.target_lang]}, src=True
+            )
+        tgt_dict = src_dict
+    else:
+        if args.srcdict:
+            src_dict = task.load_dictionary(args.srcdict)
+        else:
+            assert args.trainpref, "--trainpref must be set if --srcdict is not specified"
+            src_dict = build_dictionary([train_path(args.source_lang)], src=True)
+
+        if target:
+            if args.tgtdict:
+                tgt_dict = task.load_dictionary(args.tgtdict)
+            else:
+                assert args.trainpref, "--trainpref must be set if --tgtdict is not specified"
+                tgt_dict = build_dictionary([train_path(args.target_lang)], tgt=True)
+        else:
+            tgt_dict = None
+
+    src_dict.save(dict_path(args.source_lang))
+    if target and tgt_dict is not None:
+        tgt_dict.save(dict_path(args.target_lang))
+
+    def make_binary_dataset(vocab, input_prefix, output_prefix, lang, num_workers):
+        print("| [{}] Dictionary: {} types".format(lang, len(vocab) - 1))
+        n_seq_tok = [0, 0]
+        replaced = Counter()
+
+        def merge_result(worker_result):
+            replaced.update(worker_result["replaced"])
+            n_seq_tok[0] += worker_result["nseq"]
+            n_seq_tok[1] += worker_result["ntok"]
+
+        input_file = "{}{}".format(
+            input_prefix, ("." + lang) if lang is not None else ""
+        )
+        offsets = Binarizer.find_offsets(input_file, num_workers)
+        pool = None
+        if num_workers > 1:
+            pool = Pool(processes=num_workers - 1)
+            for worker_id in range(1, num_workers):
+                prefix = "{}{}".format(output_prefix, worker_id)
+                pool.apply_async(
+                    binarize,
+                    (
+                        args,
+                        input_file,
+                        vocab,
+                        prefix,
+                        lang,
+                        offsets[worker_id],
+                        offsets[worker_id + 1]
+                    ),
+                    callback=merge_result
+                )
+            pool.close()
+
+        ds = indexed_dataset.make_builder(dataset_dest_file(args, output_prefix, lang, "bin"),
+                                          impl=args.dataset_impl, vocab_size=len(vocab))
+        merge_result(
+            Binarizer.binarize(
+                input_file, vocab, lambda t: ds.add_item(t),
+                offset=0, end=offsets[1]
+            )
+        )
+        if num_workers > 1:
+            pool.join()
+            for worker_id in range(1, num_workers):
+                prefix = "{}{}".format(output_prefix, worker_id)
+                temp_file_path = dataset_dest_prefix(args, prefix, lang)
+                ds.merge_file_(temp_file_path)
+                os.remove(indexed_dataset.data_file_path(temp_file_path))
+                os.remove(indexed_dataset.index_file_path(temp_file_path))
+
+        ds.finalize(dataset_dest_file(args, output_prefix, lang, "idx"))
+
+        print(
+            "| [{}] {}: {} sents, {} tokens, {:.3}% replaced by {}".format(
+                lang,
+                input_file,
+                n_seq_tok[0],
+                n_seq_tok[1],
+                100 * sum(replaced.values()) / n_seq_tok[1],
+                vocab.unk_word,
+            )
+        )
+
+    def make_binary_alignment_dataset(input_prefix, output_prefix, num_workers):
+        nseq = [0]
+
+        def merge_result(worker_result):
+            nseq[0] += worker_result['nseq']
+
+        input_file = input_prefix
+        offsets = Binarizer.find_offsets(input_file, num_workers)
+        pool = None
+        if num_workers > 1:
+            pool = Pool(processes=num_workers - 1)
+            for worker_id in range(1, num_workers):
+                prefix = "{}{}".format(output_prefix, worker_id)
+                pool.apply_async(
+                    binarize_alignments,
+                    (
+                        args,
+                        input_file,
+                        utils.parse_alignment,
+                        prefix,
+                        offsets[worker_id],
+                        offsets[worker_id + 1]
+                    ),
+                    callback=merge_result
+                )
+            pool.close()
+
+        ds = indexed_dataset.make_builder(dataset_dest_file(args, output_prefix, None, "bin"),
+                                          impl=args.dataset_impl)
+
+        merge_result(
+            Binarizer.binarize_alignments(
+                input_file, utils.parse_alignment, lambda t: ds.add_item(t),
+                offset=0, end=offsets[1]
+            )
+        )
+        if num_workers > 1:
+            pool.join()
+            for worker_id in range(1, num_workers):
+                prefix = "{}{}".format(output_prefix, worker_id)
+                temp_file_path = dataset_dest_prefix(args, prefix, None)
+                ds.merge_file_(temp_file_path)
+                os.remove(indexed_dataset.data_file_path(temp_file_path))
+                os.remove(indexed_dataset.index_file_path(temp_file_path))
+
+        ds.finalize(dataset_dest_file(args, output_prefix, None, "idx"))
+
+        print(
+            "| [alignments] {}: parsed {} alignments".format(
+                input_file,
+                nseq[0]
+            )
+        )
+
+    def make_dataset(vocab, input_prefix, output_prefix, lang, num_workers=1):
+        if args.dataset_impl == "raw":
+            # Copy original text file to destination folder
+            output_text_file = dest_path(
+                output_prefix + ".{}-{}".format(args.source_lang, args.target_lang),
+                lang,
+            )
+            shutil.copyfile(file_name(input_prefix, lang), output_text_file)
+        else:
+            make_binary_dataset(vocab, input_prefix, output_prefix, lang, num_workers)
+
+    def make_all(lang, vocab):
+        if args.trainpref:
+            make_dataset(vocab, args.trainpref, "train", lang, num_workers=args.workers)
+        if args.validpref:
+            for k, validpref in enumerate(args.validpref.split(",")):
+                outprefix = "valid{}".format(k) if k > 0 else "valid"
+                make_dataset(vocab, validpref, outprefix, lang, num_workers=args.workers)
+        if args.testpref:
+            for k, testpref in enumerate(args.testpref.split(",")):
+                outprefix = "test{}".format(k) if k > 0 else "test"
+                make_dataset(vocab, testpref, outprefix, lang, num_workers=args.workers)
+
+    def make_all_alignments():
+        if args.trainpref and os.path.exists(args.trainpref + "." + args.align_suffix):
+            make_binary_alignment_dataset(args.trainpref + "." + args.align_suffix, "train.align", num_workers=args.workers)
+        if args.validpref and os.path.exists(args.validpref + "." + args.align_suffix):
+            make_binary_alignment_dataset(args.validpref + "." + args.align_suffix, "valid.align", num_workers=args.workers)
+        if args.testpref and os.path.exists(args.testpref + "." + args.align_suffix):
+            make_binary_alignment_dataset(args.testpref + "." + args.align_suffix, "test.align", num_workers=args.workers)
+
+    make_all(args.source_lang, src_dict)
+    if target:
+        make_all(args.target_lang, tgt_dict)
+    if args.align_suffix:
+        make_all_alignments()
+
+    print("| Wrote preprocessed data to {}".format(args.destdir))
+
+    if args.alignfile:
+        assert args.trainpref, "--trainpref must be set if --alignfile is specified"
+        src_file_name = train_path(args.source_lang)
+        tgt_file_name = train_path(args.target_lang)
+        freq_map = {}
+        with open(args.alignfile, "r", encoding='utf-8') as align_file:
+            with open(src_file_name, "r", encoding='utf-8') as src_file:
+                with open(tgt_file_name, "r", encoding='utf-8') as tgt_file:
+                    for a, s, t in zip_longest(align_file, src_file, tgt_file):
+                        si = src_dict.encode_line(s, add_if_not_exist=False)
+                        ti = tgt_dict.encode_line(t, add_if_not_exist=False)
+                        ai = list(map(lambda x: tuple(x.split("-")), a.split()))
+                        for sai, tai in ai:
+                            srcidx = si[int(sai)]
+                            tgtidx = ti[int(tai)]
+                            if srcidx != src_dict.unk() and tgtidx != tgt_dict.unk():
+                                assert srcidx != src_dict.pad()
+                                assert srcidx != src_dict.eos()
+                                assert tgtidx != tgt_dict.pad()
+                                assert tgtidx != tgt_dict.eos()
+
+                                if srcidx not in freq_map:
+                                    freq_map[srcidx] = {}
+                                if tgtidx not in freq_map[srcidx]:
+                                    freq_map[srcidx][tgtidx] = 1
+                                else:
+                                    freq_map[srcidx][tgtidx] += 1
+
+        align_dict = {}
+        for srcidx in freq_map.keys():
+            align_dict[srcidx] = max(freq_map[srcidx], key=freq_map[srcidx].get)
+
+        with open(
+                os.path.join(
+                    args.destdir,
+                    "alignment.{}-{}.txt".format(args.source_lang, args.target_lang),
+                ),
+                "w", encoding='utf-8'
+        ) as f:
+            for k, v in align_dict.items():
+                print("{} {}".format(src_dict[k], tgt_dict[v]), file=f)
+
+
+def binarize(args, filename, vocab, output_prefix, lang, offset, end, append_eos=True):
+    ds = indexed_dataset.make_builder(dataset_dest_file(args, output_prefix, lang, "bin"),
+                                      impl=args.dataset_impl, vocab_size=len(vocab))
+
+    def consumer(tensor):
+        ds.add_item(tensor)
+
+    res = Binarizer.binarize(filename, vocab, consumer, append_eos=append_eos,
+                             offset=offset, end=end)
+    ds.finalize(dataset_dest_file(args, output_prefix, lang, "idx"))
+    return res
+
+
+def binarize_alignments(args, filename, parse_alignment, output_prefix, offset, end):
+    ds = indexed_dataset.make_builder(dataset_dest_file(args, output_prefix, None, "bin"),
+                                      impl=args.dataset_impl, vocab_size=None)
+
+    def consumer(tensor):
+        ds.add_item(tensor)
+
+    res = Binarizer.binarize_alignments(filename, parse_alignment, consumer, offset=offset,
+                                        end=end)
+    ds.finalize(dataset_dest_file(args, output_prefix, None, "idx"))
+    return res
+
+
+def dataset_dest_prefix(args, output_prefix, lang):
+    base = "{}/{}".format(args.destdir, output_prefix)
+    if lang is not None:
+        lang_part = ".{}-{}.{}".format(args.source_lang, args.target_lang, lang)
+    elif args.only_source:
+        lang_part = ""
+    else:
+        lang_part = ".{}-{}".format(args.source_lang, args.target_lang)
+
+    return "{}{}".format(base, lang_part)
+
+
+def dataset_dest_file(args, output_prefix, lang, extension):
+    base = dataset_dest_prefix(args, output_prefix, lang)
+    return "{}.{}".format(base, extension)
+
+
+def get_offsets(input_file, num_workers):
+    return Binarizer.find_offsets(input_file, num_workers)
+
+
+def cli_main():
+    parser = options.get_preprocessing_parser()
+    args = parser.parse_args()
+    main(args)
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/infoxlm/fairseq/fairseq_cli/score.py
+++ b/infoxlm/fairseq/fairseq_cli/score.py
@@ -1,1 +1,88 @@
-../score.py
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+BLEU scoring of generated translations against reference translations.
+"""
+
+import argparse
+import os
+import sys
+
+from fairseq import bleu
+from fairseq.data import dictionary
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description='Command-line script for BLEU scoring.')
+    # fmt: off
+    parser.add_argument('-s', '--sys', default='-', help='system output')
+    parser.add_argument('-r', '--ref', required=True, help='references')
+    parser.add_argument('-o', '--order', default=4, metavar='N',
+                        type=int, help='consider ngrams up to this order')
+    parser.add_argument('--ignore-case', action='store_true',
+                        help='case-insensitive scoring')
+    parser.add_argument('--sacrebleu', action='store_true',
+                        help='score with sacrebleu')
+    parser.add_argument('--sentence-bleu', action='store_true',
+                        help='report sentence-level BLEUs (i.e., with +1 smoothing)')
+    # fmt: on
+    return parser
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    print(args)
+
+    assert args.sys == '-' or os.path.exists(args.sys), \
+        "System output file {} does not exist".format(args.sys)
+    assert os.path.exists(args.ref), \
+        "Reference file {} does not exist".format(args.ref)
+
+    dict = dictionary.Dictionary()
+
+    def readlines(fd):
+        for line in fd.readlines():
+            if args.ignore_case:
+                yield line.lower()
+            else:
+                yield line
+
+    if args.sacrebleu:
+        import sacrebleu
+
+        def score(fdsys):
+            with open(args.ref) as fdref:
+                print(sacrebleu.corpus_bleu(fdsys, [fdref]))
+    elif args.sentence_bleu:
+        def score(fdsys):
+            with open(args.ref) as fdref:
+                scorer = bleu.Scorer(dict.pad(), dict.eos(), dict.unk())
+                for i, (sys_tok, ref_tok) in enumerate(zip(readlines(fdsys), readlines(fdref))):
+                    scorer.reset(one_init=True)
+                    sys_tok = dict.encode_line(sys_tok)
+                    ref_tok = dict.encode_line(ref_tok)
+                    scorer.add(ref_tok, sys_tok)
+                    print(i, scorer.result_string(args.order))
+    else:
+        def score(fdsys):
+            with open(args.ref) as fdref:
+                scorer = bleu.Scorer(dict.pad(), dict.eos(), dict.unk())
+                for sys_tok, ref_tok in zip(readlines(fdsys), readlines(fdref)):
+                    sys_tok = dict.encode_line(sys_tok)
+                    ref_tok = dict.encode_line(ref_tok)
+                    scorer.add(ref_tok, sys_tok)
+                print(scorer.result_string(args.order))
+
+    if args.sys == '-':
+        score(sys.stdin)
+    else:
+        with open(args.sys, 'r') as f:
+            score(f)
+
+
+if __name__ == '__main__':
+    main()

--- a/infoxlm/fairseq/fairseq_cli/setup.py
+++ b/infoxlm/fairseq/fairseq_cli/setup.py
@@ -1,1 +1,162 @@
-../setup.py
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from setuptools import setup, find_packages, Extension
+import sys
+
+
+if sys.version_info < (3, 5):
+    sys.exit('Sorry, Python >=3.5 is required for fairseq.')
+
+
+with open('README.md') as f:
+    readme = f.read()
+
+
+if sys.platform == 'darwin':
+    extra_compile_args = ['-stdlib=libc++', '-O3']
+else:
+    extra_compile_args = ['-std=c++11', '-O3']
+
+
+class NumpyExtension(Extension):
+    """Source: https://stackoverflow.com/a/54128391"""
+
+    def __init__(self, *args, **kwargs):
+        self.__include_dirs = []
+        super().__init__(*args, **kwargs)
+
+    @property
+    def include_dirs(self):
+        import numpy
+        return self.__include_dirs + [numpy.get_include()]
+
+    @include_dirs.setter
+    def include_dirs(self, dirs):
+        self.__include_dirs = dirs
+
+
+extensions = [
+    Extension(
+        'fairseq.libbleu',
+        sources=[
+            'fairseq/clib/libbleu/libbleu.cpp',
+            'fairseq/clib/libbleu/module.cpp',
+        ],
+        extra_compile_args=extra_compile_args,
+    ),
+    NumpyExtension(
+        'fairseq.data.data_utils_fast',
+        sources=['fairseq/data/data_utils_fast.pyx'],
+        language='c++',
+        extra_compile_args=extra_compile_args,
+    ),
+    NumpyExtension(
+        'fairseq.data.token_block_utils_fast',
+        sources=['fairseq/data/token_block_utils_fast.pyx'],
+        language='c++',
+        extra_compile_args=extra_compile_args,
+    ),
+]
+
+
+cmdclass = {}
+
+
+try:
+    # torch is not available when generating docs
+    from torch.utils import cpp_extension
+    extensions.extend([
+        cpp_extension.CppExtension(
+            'fairseq.libnat',
+            sources=[
+                'fairseq/clib/libnat/edit_dist.cpp',
+            ],
+        ),
+    ])
+    cmdclass['build_ext'] = cpp_extension.BuildExtension
+except ImportError:
+    pass
+
+
+if 'READTHEDOCS' in os.environ:
+    # don't build extensions when generating docs
+    extensions = []
+    if 'build_ext' in cmdclass:
+        del cmdclass['build_ext']
+
+    # use CPU build of PyTorch
+    dependency_links = [
+        'https://download.pytorch.org/whl/cpu/torch-1.3.0%2Bcpu-cp36-cp36m-linux_x86_64.whl'
+    ]
+else:
+    dependency_links = []
+
+
+if 'clean' in sys.argv[1:]:
+    # Source: https://bit.ly/2NLVsgE
+    print("deleting Cython files...")
+    import subprocess
+    subprocess.run(['rm -f fairseq/*.so fairseq/**/*.so'], shell=True)
+
+
+if 'test' in sys.argv[1:]:
+    try:
+        import fairseq.data.token_block_utils_fast
+    except (ImportError, ModuleNotFoundError):
+        raise Exception(
+            'Please install Cython components with `python setup.py build_ext --inplace`'
+            'before running unit tests.'
+        )
+
+
+setup(
+    name='fairseq',
+    version='0.9.0',
+    description='Facebook AI Research Sequence-to-Sequence Toolkit',
+    url='https://github.com/pytorch/fairseq',
+    classifiers=[
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    ],
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    setup_requires=[
+        'cython',
+        'numpy',
+        'setuptools>=18.0',
+    ],
+    install_requires=[
+        'cffi',
+        'cython',
+        'numpy',
+        'regex',
+        'sacrebleu',
+        'torch',
+        'tqdm',
+    ],
+    dependency_links=dependency_links,
+    packages=find_packages(exclude=['scripts', 'tests']),
+    ext_modules=extensions,
+    test_suite='tests',
+    entry_points={
+        'console_scripts': [
+            'fairseq-eval-lm = fairseq_cli.eval_lm:cli_main',
+            'fairseq-generate = fairseq_cli.generate:cli_main',
+            'fairseq-interactive = fairseq_cli.interactive:cli_main',
+            'fairseq-preprocess = fairseq_cli.preprocess:cli_main',
+            'fairseq-score = fairseq_cli.score:main',
+            'fairseq-train = fairseq_cli.train:cli_main',
+            'fairseq-validate = fairseq_cli.validate:cli_main',
+        ],
+    },
+    cmdclass=cmdclass,
+    zip_safe=False,
+)

--- a/infoxlm/fairseq/fairseq_cli/train.py
+++ b/infoxlm/fairseq/fairseq_cli/train.py
@@ -1,1 +1,362 @@
-../train.py
+#!/usr/bin/env python3 -u
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Train a new model on one or across multiple GPUs.
+"""
+
+import collections
+import math
+import random
+
+import numpy as np
+import torch
+
+from fairseq import checkpoint_utils, distributed_utils, options, progress_bar, tasks, utils
+from fairseq.data import iterators
+from fairseq.trainer import Trainer
+from fairseq.meters import AverageMeter, StopwatchMeter
+
+
+def main(args, init_distributed=False):
+    utils.import_user_module(args)
+
+    assert args.max_tokens is not None or args.max_sentences is not None, \
+        'Must specify batch size either with --max-tokens or --max-sentences'
+
+    # Initialize CUDA and distributed training
+    if torch.cuda.is_available() and not args.cpu:
+        torch.cuda.set_device(args.device_id)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if init_distributed:
+        args.distributed_rank = distributed_utils.distributed_init(args)
+
+    if distributed_utils.is_master(args):
+        checkpoint_utils.verify_checkpoint_directory(args.save_dir)
+
+    # Print args
+    print(args)
+
+    # Setup task, e.g., translation, language modeling, etc.
+    task = tasks.setup_task(args)
+
+    # Load valid dataset (we load training data below, based on the latest checkpoint)
+    for valid_sub_split in args.valid_subset.split(','):
+        task.load_dataset(valid_sub_split, combine=False, epoch=0)
+
+    # Build model and criterion
+    model = task.build_model(args)
+    criterion = task.build_criterion(args)
+    print(model)
+    print('| model {}, criterion {}'.format(args.arch, criterion.__class__.__name__))
+    print('| num. model params: {} (num. trained: {})'.format(
+        sum(p.numel() for p in model.parameters()),
+        sum(p.numel() for p in model.parameters() if p.requires_grad),
+    ))
+
+    # Build trainer
+    trainer = Trainer(args, task, model, criterion)
+    print('| training on {} GPUs'.format(args.distributed_world_size))
+    print('| max tokens per GPU = {} and max sentences per GPU = {}'.format(
+        args.max_tokens,
+        args.max_sentences,
+    ))
+
+    # Load the latest checkpoint if one is available and restore the
+    # corresponding train iterator
+    extra_state, epoch_itr = checkpoint_utils.load_checkpoint(args, trainer)
+
+    # Prepare train
+    task.prepare_train(model, criterion)
+
+    # Train until the learning rate gets too small
+    max_epoch = args.max_epoch or math.inf
+    max_update = args.max_update or math.inf
+    lr = trainer.get_lr()
+    train_meter = StopwatchMeter()
+    train_meter.start()
+    valid_subsets = args.valid_subset.split(',')
+    while (
+        lr > args.min_lr
+        and (epoch_itr.epoch < max_epoch or (epoch_itr.epoch == max_epoch
+            and epoch_itr._next_epoch_itr is not None))
+        and trainer.get_num_updates() < max_update
+    ):
+        # train for one epoch
+        train(args, trainer, task, epoch_itr)
+
+        if not args.disable_validation and epoch_itr.epoch % args.validate_interval == 0:
+            valid_losses = validate(args, trainer, task, epoch_itr, valid_subsets)
+        else:
+            valid_losses = [None]
+
+        # only use first validation loss to update the learning rate
+        lr = trainer.lr_step(epoch_itr.epoch, valid_losses[0])
+
+        # save checkpoint
+        if epoch_itr.epoch % args.save_interval == 0:
+            checkpoint_utils.save_checkpoint(args, trainer, epoch_itr, valid_losses[0])
+
+        reload_dataset = ':' in getattr(args, 'data', '')
+        reload_dataset = reload_dataset or args.reload_dataset_per_epoch
+        # sharded data: get train iterator for next epoch
+        epoch_itr = trainer.get_train_iterator(epoch_itr.epoch, load_dataset=reload_dataset)
+    train_meter.stop()
+    print('| done training in {:.1f} seconds'.format(train_meter.sum))
+
+
+def train(args, trainer, task, epoch_itr):
+    """Train the model for one epoch."""
+    # Update parameters every N batches
+    print("| Start train.train ..." , flush=True)
+    update_freq = args.update_freq[epoch_itr.epoch - 1] \
+        if epoch_itr.epoch <= len(args.update_freq) else args.update_freq[-1]
+
+    # Initialize data iterator
+    itr = epoch_itr.next_epoch_itr(
+        fix_batches_to_gpus=args.fix_batches_to_gpus,
+        shuffle=(epoch_itr.epoch >= args.curriculum),
+    )
+    print("| Itr init (1) ...", flush=True)
+    itr = iterators.GroupedIterator(itr, update_freq)
+    progress = progress_bar.build_progress_bar(
+        args, itr, epoch_itr.epoch, no_progress_bar='simple',
+    )
+    print("| Itr init (2) ...", flush=True)
+
+    extra_meters = collections.defaultdict(lambda: AverageMeter())
+    valid_subsets = args.valid_subset.split(',')
+    max_update = args.max_update or math.inf
+    
+    # ##################### DEBUG #####################
+    
+    # debug_samples = []
+    # print("Fetch debug examples ...")
+    # for i in range(1000):
+    #     debug_samples.append(next(itr))
+    
+    # progress = progress_bar.build_progress_bar(
+    #     args, iter(debug_samples), epoch_itr.epoch, no_progress_bar='simple',
+    # )
+
+    # ##################### DEBUG #####################
+
+    for i, samples in enumerate(progress, start=epoch_itr.iterations_in_epoch):
+        log_output = trainer.train_step(samples)
+        if log_output is None:
+            continue
+
+        # log mid-epoch stats
+        stats = get_training_stats(trainer)
+        for k, v in log_output.items():
+            if k in ['loss', 'nll_loss', 'ntokens', 'nsentences', 'sample_size']:
+                continue  # these are already logged above
+            if 'loss' in k or k == 'accuracy':
+                extra_meters[k].update(v, log_output['sample_size'])
+            else:
+                extra_meters[k].update(v)
+            stats[k] = extra_meters[k].val
+        progress.log(stats, tag='train', step=stats['num_updates'])
+
+        # ignore the first mini-batch in words-per-second and updates-per-second calculation
+        if i == 0:
+            trainer.get_meter('wps').reset()
+            trainer.get_meter('ups').reset()
+
+        num_updates = trainer.get_num_updates()
+        if (
+            not args.disable_validation
+            and args.save_interval_updates > 0
+            and num_updates % args.save_interval_updates == 0
+            and num_updates > 0
+        ):
+            valid_losses = validate(args, trainer, task, epoch_itr, valid_subsets)
+            checkpoint_utils.save_checkpoint(args, trainer, epoch_itr, valid_losses[0])
+        elif (args.save_interval_updates > 0
+            and num_updates % args.save_interval_updates == 0
+            and num_updates > 0):
+            checkpoint_utils.save_checkpoint(args, trainer, epoch_itr, None)
+
+        if num_updates >= max_update:
+            break
+
+    # log end-of-epoch stats
+    stats = get_training_stats(trainer)
+    for k, meter in extra_meters.items():
+        stats[k] = meter.val
+    progress.print(stats, tag='train', step=stats['num_updates'])
+
+    # reset training meters
+    for k in [
+        'train_loss', 'train_nll_loss', 'wps', 'ups', 'wpb', 'bsz', 'gnorm', 'clip',
+    ]:
+        meter = trainer.get_meter(k)
+        if meter is not None:
+            meter.reset()
+
+
+def get_training_stats(trainer):
+    stats = collections.OrderedDict()
+    stats['loss'] = trainer.get_meter('train_loss')
+    if trainer.get_meter('train_nll_loss').count > 0:
+        nll_loss = trainer.get_meter('train_nll_loss')
+        stats['nll_loss'] = nll_loss
+    else:
+        nll_loss = trainer.get_meter('train_loss')
+    stats['ppl'] = utils.get_perplexity(nll_loss.avg)
+    stats['wps'] = trainer.get_meter('wps')
+    stats['ups'] = trainer.get_meter('ups')
+    stats['wpb'] = trainer.get_meter('wpb')
+    stats['bsz'] = trainer.get_meter('bsz')
+    stats['num_updates'] = trainer.get_num_updates()
+    stats['lr'] = trainer.get_lr()
+    stats['gnorm'] = trainer.get_meter('gnorm')
+    stats['clip'] = trainer.get_meter('clip')
+    stats['oom'] = trainer.get_meter('oom')
+    if trainer.get_meter('loss_scale') is not None:
+        stats['loss_scale'] = trainer.get_meter('loss_scale')
+    stats['wall'] = round(trainer.get_meter('wall').elapsed_time)
+    stats['train_wall'] = trainer.get_meter('train_wall')
+    return stats
+
+
+def validate(args, trainer, task, epoch_itr, subsets):
+    """Evaluate the model on the validation set(s) and return the losses."""
+
+    if args.fixed_validation_seed is not None:
+        # set fixed seed for every validation
+        utils.set_torch_seed(args.fixed_validation_seed)
+
+    valid_losses = []
+    for subset in subsets:
+        # Initialize data iterator
+        itr = task.get_batch_iterator(
+            dataset=task.dataset(subset),
+            max_tokens=args.max_tokens_valid,
+            max_sentences=args.max_sentences_valid,
+            max_positions=utils.resolve_max_positions(
+                task.max_positions(),
+                trainer.get_model().max_positions(),
+            ),
+            ignore_invalid_inputs=args.skip_invalid_size_inputs_valid_test,
+            required_batch_size_multiple=args.required_batch_size_multiple,
+            seed=args.seed,
+            num_shards=args.distributed_world_size,
+            shard_id=args.distributed_rank,
+            num_workers=args.num_workers,
+        ).next_epoch_itr(shuffle=False)
+        progress = progress_bar.build_progress_bar(
+            args, itr, epoch_itr.epoch,
+            prefix='valid on \'{}\' subset'.format(subset),
+            no_progress_bar='simple'
+        )
+
+        # reset validation loss meters
+        for k in ['valid_loss', 'valid_nll_loss']:
+            meter = trainer.get_meter(k)
+            if meter is not None:
+                meter.reset()
+        extra_meters = collections.defaultdict(lambda: AverageMeter())
+
+        for sample in progress:
+            log_output = trainer.valid_step(sample)
+
+            for k, v in log_output.items():
+                if k in ['loss', 'nll_loss', 'ntokens', 'nsentences', 'sample_size']:
+                    continue
+                extra_meters[k].update(v)
+
+        # log validation stats
+        stats = get_valid_stats(trainer, args, extra_meters)
+        for k, meter in extra_meters.items():
+            stats[k] = meter.avg
+        progress.print(stats, tag=subset, step=trainer.get_num_updates())
+
+        valid_losses.append(
+            stats[args.best_checkpoint_metric].avg
+            if args.best_checkpoint_metric == 'loss'
+            else stats[args.best_checkpoint_metric]
+        )
+    return valid_losses
+
+
+def get_valid_stats(trainer, args, extra_meters=None):
+    stats = collections.OrderedDict()
+    stats['loss'] = trainer.get_meter('valid_loss')
+    if trainer.get_meter('valid_nll_loss').count > 0:
+        nll_loss = trainer.get_meter('valid_nll_loss')
+        stats['nll_loss'] = nll_loss
+    else:
+        nll_loss = stats['loss']
+    stats['ppl'] = utils.get_perplexity(nll_loss.avg)
+    stats['num_updates'] = trainer.get_num_updates()
+    if hasattr(checkpoint_utils.save_checkpoint, 'best'):
+        key = 'best_{0}'.format(args.best_checkpoint_metric)
+        best_function = max if args.maximize_best_checkpoint_metric else min
+
+        current_metric = None
+        if args.best_checkpoint_metric == 'loss':
+            current_metric = stats['loss'].avg
+        elif args.best_checkpoint_metric in extra_meters:
+            current_metric = extra_meters[args.best_checkpoint_metric].avg
+        elif args.best_checkpoint_metric in stats:
+            current_metric = stats[args.best_checkpoint_metric]
+        else:
+            raise ValueError("best_checkpoint_metric not found in logs")
+
+        stats[key] = best_function(
+            checkpoint_utils.save_checkpoint.best,
+            current_metric,
+        )
+    return stats
+
+
+def distributed_main(i, args, start_rank=0):
+    args.device_id = i
+    if args.distributed_rank is None:  # torch.multiprocessing.spawn
+        args.distributed_rank = start_rank + i
+    main(args, init_distributed=True)
+
+
+def cli_main():
+    parser = options.get_training_parser()
+    args = options.parse_args_and_arch(parser)
+
+    if args.distributed_init_method is None:
+        distributed_utils.infer_init_method(args)
+
+    if args.distributed_init_method is not None:
+        # distributed training
+        if torch.cuda.device_count() > 1 and not args.distributed_no_spawn:
+            start_rank = args.distributed_rank
+            args.distributed_rank = None  # assign automatically
+            torch.multiprocessing.spawn(
+                fn=distributed_main,
+                args=(args, start_rank),
+                nprocs=torch.cuda.device_count(),
+            )
+        else:
+            distributed_main(args.device_id, args)
+    elif args.distributed_world_size > 1:
+        # fallback for single node with multiple GPUs
+        assert args.distributed_world_size <= torch.cuda.device_count()
+        port = random.randint(10000, 20000)
+        args.distributed_init_method = 'tcp://localhost:{port}'.format(port=port)
+        args.distributed_rank = None  # set based on device id
+        if max(args.update_freq) > 1 and args.ddp_backend != 'no_c10d':
+            print('| NOTE: you may get better performance with: --ddp-backend=no_c10d')
+        torch.multiprocessing.spawn(
+            fn=distributed_main,
+            args=(args, ),
+            nprocs=args.distributed_world_size,
+        )
+    else:
+        # single GPU training
+        main(args)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/kosmos-2.5/inference.py
+++ b/kosmos-2.5/inference.py
@@ -317,7 +317,7 @@ def get_ocr_res(tokenizer, tokens, p2s_resized_width, p2s_resized_height, raw_wi
 			x1 = int(cur_bbox[2][1:-1].split('_')[-1])
 			y1 = int(cur_bbox[3][1:-1].split('_')[-1])
 			pass
-		except:
+		except Exception:
 			print('w')
 			continue
 		cur_token.append(cur_line)

--- a/kosmos-2.5/kosmos2_5/tasks/generation.py
+++ b/kosmos-2.5/kosmos2_5/tasks/generation.py
@@ -66,7 +66,7 @@ class customDataset(FairseqDataset):
     def collater(self, samples):
         try:
             return torch.stack(samples)
-        except:
+        except Exception:
             return samples
 
 class RawImageDataset(FairseqDataset):

--- a/kosmos-2/data/visualize_grit.py
+++ b/kosmos-2/data/visualize_grit.py
@@ -75,7 +75,7 @@ def vis_image(json_obj, output_folder):
     
     try:
         pil_img = Image.open(output_path).convert("RGB")
-    except:
+    except Exception:
         return 
     image = np.array(pil_img)[:, :, [2, 1, 0]]
     image_h = pil_img.height
@@ -149,7 +149,7 @@ def vis_image(json_obj, output_folder):
         output_path = os.path.join(output_folder, file_key_name) 
         
         imshow(new_image, file_name= output_path, caption=caption)
-    except:
+    except Exception:
         # Out of (supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff, webp)
         return 
 

--- a/kosmos-2/evaluation/refcoco/refexp_evaluate.py
+++ b/kosmos-2/evaluation/refcoco/refexp_evaluate.py
@@ -113,7 +113,7 @@ class RefExpEvaluatorFromTxt(object):
             for k in self.k:
                 try:
                     value[k] /= dataset2count[key]
-                except:
+                except Exception:
                     pass
                 
         results = {}

--- a/kosmos-2/fairseq/examples/speech_recognition/infer.py
+++ b/kosmos-2/fairseq/examples/speech_recognition/infer.py
@@ -47,7 +47,7 @@ output units",
             default=0.2,
             help="weight for lm while interpolating with neural score",
         )
-    except:
+    except Exception:
         pass
     parser.add_argument(
         "--rnnt_len_penalty", default=-0.5, help="rnnt length penalty on word level"
@@ -206,7 +206,7 @@ class ExistingEmissionsDecoder(object):
         ids = sample["id"].cpu().numpy()
         try:
             emissions = np.stack(self.emissions[ids])
-        except:
+        except Exception:
             print([x.shape for x in self.emissions[ids]])
             raise Exception("invalid sizes")
         emissions = torch.from_numpy(emissions)

--- a/kosmos-2/fairseq/examples/speech_recognition/kaldi/kaldi_decoder.py
+++ b/kosmos-2/fairseq/examples/speech_recognition/kaldi/kaldi_decoder.py
@@ -65,7 +65,7 @@ class KaldiDecoder(object):
             )
             from kaldi.lat.functions import DeterminizeLatticePhonePrunedOptions
             from kaldi.fstext import read_fst_kaldi, SymbolTable
-        except:
+        except Exception:
             warnings.warn(
                 "pykaldi is required for this functionality. Please install from https://github.com/pykaldi/pykaldi"
             )

--- a/kosmos-2/fairseq/examples/speech_recognition/w2l_decoder.py
+++ b/kosmos-2/fairseq/examples/speech_recognition/w2l_decoder.py
@@ -38,7 +38,7 @@ try:
         Trie,
         LexiconDecoder,
     )
-except:
+except Exception:
     warnings.warn(
         "flashlight python bindings are required to use this functionality. Please install from https://github.com/facebookresearch/flashlight/tree/master/bindings/python"
     )

--- a/kosmos-2/fairseq/examples/textless_nlp/gslm/ulm/sample.py
+++ b/kosmos-2/fairseq/examples/textless_nlp/gslm/ulm/sample.py
@@ -50,7 +50,7 @@ def main(args):
     try:
         from fairseq.dataclass.utils import convert_namespace_to_omegaconf
         args = convert_namespace_to_omegaconf(args)
-    except:
+    except Exception:
         pass
 
     # if args.max_tokens is None and args.max_sentences is None:

--- a/kosmos-2/fairseq/examples/wav2vec/unsupervised/scripts/g2p_wrd_to_phn.py
+++ b/kosmos-2/fairseq/examples/wav2vec/unsupervised/scripts/g2p_wrd_to_phn.py
@@ -36,7 +36,7 @@ def main():
             phones.extend(wrd_to_phn[w])
         try:
             print(" ".join(phones))
-        except:
+        except Exception:
             print(wrd_to_phn, words, phones, file=sys.stderr)
             raise
 

--- a/kosmos-2/fairseq/examples/wav2vec/unsupervised/scripts/wav2vec_apply_cluster_faiss.py
+++ b/kosmos-2/fairseq/examples/wav2vec/unsupervised/scripts/wav2vec_apply_cluster_faiss.py
@@ -70,7 +70,7 @@ def main():
 
     try:
         faiss_spec = parse_faiss_specs(spec.rstrip("/"))[0]
-    except:
+    except Exception:
         print(spec)
         raise
 

--- a/kosmos-2/fairseq/examples/wav2vec/unsupervised/tasks/unpaired_audio_text.py
+++ b/kosmos-2/fairseq/examples/wav2vec/unsupervised/tasks/unpaired_audio_text.py
@@ -264,7 +264,7 @@ class UnpairedAudioText(FairseqTask):
 
         try:
             world_size = get_data_parallel_world_size()
-        except:
+        except Exception:
             world_size = 1
 
         logging_output = {

--- a/kosmos-2/fairseq/examples/wav2vec/unsupervised/w2vu_generate.py
+++ b/kosmos-2/fairseq/examples/wav2vec/unsupervised/w2vu_generate.py
@@ -694,7 +694,7 @@ def cli_main():
         from hydra._internal.utils import get_args
 
         cfg_name = get_args().config_name or "config"
-    except:
+    except Exception:
         logger.warning("Failed to get config name from hydra args")
         cfg_name = "config"
 

--- a/kosmos-2/fairseq/examples/wav2vec/vq-wav2vec_featurize.py
+++ b/kosmos-2/fairseq/examples/wav2vec/vq-wav2vec_featurize.py
@@ -23,7 +23,7 @@ from torch.utils.data import DataLoader
 
 try:
     import tqdm
-except:
+except Exception:
     print("Install tqdm to use --log-format=tqdm")
 
 

--- a/kosmos-2/fairseq/fairseq/data/audio/raw_audio_dataset.py
+++ b/kosmos-2/fairseq/fairseq/data/audio/raw_audio_dataset.py
@@ -298,7 +298,7 @@ class FileAudioDataset(RawAudioDataset):
             import pyarrow
 
             self.fnames = pyarrow.array(self.fnames)
-        except:
+        except Exception:
             logger.debug(
                 "Could not create a pyarrow array. Please install pyarrow for better performance"
             )

--- a/kosmos-2/fairseq/fairseq/data/encoders/gpt2_bpe_utils.py
+++ b/kosmos-2/fairseq/fairseq/data/encoders/gpt2_bpe_utils.py
@@ -91,7 +91,7 @@ class Encoder:
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/kosmos-2/fairseq/fairseq/dataclass/utils.py
+++ b/kosmos-2/fairseq/fairseq/dataclass/utils.py
@@ -267,7 +267,7 @@ def _override_attr(
         ):
             try:
                 val = field_type(val)
-            except:
+            except Exception:
                 pass  # ignore errors here, they are often from interpolation args
 
         if val is None:
@@ -387,7 +387,7 @@ def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:
     with initialize(config_path=config_path):
         try:
             composed_cfg = compose("config", overrides=overrides, strict=False)
-        except:
+        except Exception:
             logger.error("Error when composing. Overrides: " + str(overrides))
             raise
 

--- a/kosmos-2/fairseq/fairseq/models/distributed_fairseq_model.py
+++ b/kosmos-2/fairseq/fairseq/models/distributed_fairseq_model.py
@@ -75,7 +75,7 @@ def DistributedFairseqModel(args, model, process_group, device):
                     register_ddp_comm_hook,
                     DDPCommHookType,
                 )
-            except:
+            except Exception:
                 logger.error(
                     "Could not import from torch.distributed.algorithms.ddp_comm_hooks; you may need to update your pytorch version"
                 )

--- a/kosmos-2/fairseq/fairseq/modules/fp32_batch_norm.py
+++ b/kosmos-2/fairseq/fairseq/modules/fp32_batch_norm.py
@@ -35,7 +35,7 @@ class Fp32BatchNorm(nn.Module):
                     try:
                         self.bn.weight = self.bn.weight.float()
                         self.bn.bias = self.bn.bias.float()
-                    except:
+                    except Exception:
                         self.bn.float()
             else:
                 self.bn.float()

--- a/kosmos-2/fairseq/fairseq_cli/generate.py
+++ b/kosmos-2/fairseq/fairseq_cli/generate.py
@@ -112,7 +112,7 @@ def _main(cfg: DictConfig, output_file):
             lms, _ = checkpoint_utils.load_model_ensemble(
                 [cfg.generation.lm_path], arg_overrides=overrides, task=None
             )
-        except:
+        except Exception:
             logger.warning(
                 f"Failed to load language model! Please make sure that the language model dict is the same "
                 f"as target dict and is located in the data dir ({cfg.task.data})"

--- a/kosmos-2/fairseq/fairseq_cli/hydra_train.py
+++ b/kosmos-2/fairseq/fairseq_cli/hydra_train.py
@@ -65,7 +65,7 @@ def _hydra_main(cfg: FairseqConfig, **kwargs) -> float:
         best_val = metrics.get_smoothed_value(
             "valid", cfg.checkpoint.best_checkpoint_metric
         )
-    except:
+    except Exception:
         best_val = None
 
     if best_val is None:
@@ -79,7 +79,7 @@ def cli_main():
         from hydra._internal.utils import get_args
 
         cfg_name = get_args().config_name or "config"
-    except:
+    except Exception:
         logger.warning("Failed to get config name from hydra args")
         cfg_name = "config"
 

--- a/kosmos-2/open_clip/src/data/gather_cc.py
+++ b/kosmos-2/open_clip/src/data/gather_cc.py
@@ -16,7 +16,7 @@ def grab(line):
     uid, split, line = line
     try:
         caption, url = line.split("\t")[:2]
-    except:
+    except Exception:
         print("Parse error")
         return
 
@@ -48,7 +48,7 @@ def grab(line):
 
             print("Success", o.shape, uid, url)
             return uid, caption, url
-        except:
+        except Exception:
             print("Failed", uid, url)
             
     except Exception as e:

--- a/kosmos-2/open_clip/src/open_clip/tokenizer.py
+++ b/kosmos-2/open_clip/src/open_clip/tokenizer.py
@@ -112,7 +112,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/layoutlm/deprecated/examples/classification/run_classification.py
+++ b/layoutlm/deprecated/examples/classification/run_classification.py
@@ -29,7 +29,7 @@ from layoutlm.data.rvl_cdip import CdipProcessor, load_and_cache_examples
 
 try:
     from torch.utils.tensorboard import SummaryWriter
-except:
+except Exception:
     from tensorboardX import SummaryWriter
 
 

--- a/layoutlmv3/examples/object_detection/ditod/table_evaluation/evaluate.py
+++ b/layoutlmv3/examples/object_detection/ditod/table_evaluation/evaluate.py
@@ -198,7 +198,7 @@ class eval:
                     resToCell = cell_mapping[ar.toText]
                     # make a mapped adjacency relation
                     lMappedAR.append(AdjRelation(resFromCell, resToCell, ar.direction))
-                except:
+                except Exception:
                     # no mapping is possible
                     pass
 
@@ -319,7 +319,7 @@ def calc_table_score(result_path):
 
             correct_nine += each_file.result[3].truePos
             res_nine += each_file.result[3].resTotal
-        except:
+        except Exception:
             print("Error occur in processing result list.")
             print(each_file.result[-1])
             break

--- a/layoutreader/run_seq2seq.py
+++ b/layoutreader/run_seq2seq.py
@@ -13,7 +13,7 @@ from torch.utils.data.distributed import DistributedSampler
 
 try:
     from torch.utils.tensorboard import SummaryWriter
-except:
+except Exception:
     from tensorboardX import SummaryWriter
 
 import tqdm

--- a/s2s-ft/run_seq2seq.py
+++ b/s2s-ft/run_seq2seq.py
@@ -13,7 +13,7 @@ from torch.utils.data.distributed import DistributedSampler
 
 try:
     from torch.utils.tensorboard import SummaryWriter
-except:
+except Exception:
     from tensorboardX import SummaryWriter
 
 import tqdm

--- a/s2s-ft/s2s_ft/modeling_decoding.py
+++ b/s2s-ft/s2s_ft/modeling_decoding.py
@@ -1095,14 +1095,14 @@ def get_div_func():
         div_func = partial(torch.div, rounding_mode='floor')
         y = div_func(x, 4)
         return div_func
-    except:
+    except Exception:
         pass
     try:
         # for pytorch 1.6 & 1.7
         div_func = torch.floor_divide
         y = div_func(x, 4)
         return div_func
-    except:
+    except Exception:
         pass
 
     div_func = torch.div

--- a/s2s-ft/s2s_ft/utils.py
+++ b/s2s-ft/s2s_ft/utils.py
@@ -13,7 +13,7 @@ import torch.utils.data
 from transformers.file_utils import WEIGHTS_NAME
 try:
     import lmdb
-except:
+except Exception:
     pass
 
 OPTIM_NAME = "optimizer.bin"

--- a/speechlm/speechlm/generate_unit.py
+++ b/speechlm/speechlm/generate_unit.py
@@ -116,7 +116,7 @@ def _main(cfg: DictConfig, output_file):
             lms, _ = checkpoint_utils.load_model_ensemble(
                 [cfg.generation.lm_path], arg_overrides=overrides, task=None
             )
-        except:
+        except Exception:
             logger.warning(
                 f"Failed to load language model! Please make sure that the language model dict is the same "
                 f"as target dict and is located in the data dir ({cfg.task.data})"

--- a/textdiffuser-2/demo_textdiffuser2_inpainting_full.py
+++ b/textdiffuser-2/demo_textdiffuser2_inpainting_full.py
@@ -440,7 +440,7 @@ def text_to_image(guest_id, i, orig_i, prompt,keywords,positive_prompt,radio,sli
                 try:
                     ocr_ids = tokenizer.encode(ocr_ids)
                     prompt = caption_ids + ocr_ids
-                except:
+                except Exception:
                     prompt = caption_ids
 
                 user_prompt = tokenizer.decode(prompt)

--- a/textdiffuser-2/demo_textdiffuser2_t2i_full.py
+++ b/textdiffuser-2/demo_textdiffuser2_t2i_full.py
@@ -324,7 +324,7 @@ def text_to_image(guest_id, prompt,keywords,positive_prompt,radio,slider_step,sl
                 try:
                     ocr_ids = tokenizer.encode(ocr_ids)
                     prompt = caption_ids + ocr_ids
-                except:
+                except Exception:
                     prompt = caption_ids
 
                 user_prompt = tokenizer.decode(prompt)

--- a/textdiffuser-2/extensions/inference_textdiffuser2_t2i_full_angle.py
+++ b/textdiffuser-2/extensions/inference_textdiffuser2_t2i_full_angle.py
@@ -587,7 +587,7 @@ def main():
             try:
                 ocr_ids = tokenizer.encode(ocr_ids)
                 prompt = caption_ids + ocr_ids
-            except:
+            except Exception:
                 prompt = caption_ids
 
             prompt = prompt[:args.max_length]

--- a/textdiffuser-2/extensions/inference_textdiffuser2_t2i_full_quadrilateral.py
+++ b/textdiffuser-2/extensions/inference_textdiffuser2_t2i_full_quadrilateral.py
@@ -595,7 +595,7 @@ def main():
             try:
                 ocr_ids = tokenizer.encode(ocr_ids)
                 prompt = caption_ids + ocr_ids
-            except:
+            except Exception:
                 prompt = caption_ids
 
             prompt = prompt[:args.max_length]

--- a/textdiffuser-2/extensions/train_textdiffuser2_t2i_full_angle.py
+++ b/textdiffuser-2/extensions/train_textdiffuser2_t2i_full_angle.py
@@ -728,7 +728,7 @@ def main():
             #### get caption
             try: #### note that few cases do not contain valid captions
                 caption = open(f'{args.dataset_path}/{first}/{second}/caption.txt').readlines()[0]
-            except:
+            except Exception:
                 caption = 'null'
                 print('erorr of caption')
             
@@ -936,7 +936,7 @@ def main():
             accelerator.print(f"Resuming from checkpoint {path}")
             try:
                 accelerator.load_state(args.resume_from_checkpoint)
-            except:
+            except Exception:
                 accelerator.load_state(os.path.join(args.output_dir, path))
             global_step = int(path.split("-")[1])
 

--- a/textdiffuser-2/extensions/train_textdiffuser2_t2i_full_quadrilateral.py
+++ b/textdiffuser-2/extensions/train_textdiffuser2_t2i_full_quadrilateral.py
@@ -711,7 +711,7 @@ def main():
             #### get caption
             try: #### note that few cases do not contain valid captions
                 caption = open(f'{args.dataset_path}/{first}/{second}/caption.txt').readlines()[0]
-            except:
+            except Exception:
                 caption = 'null'
                 print('erorr of caption')
             
@@ -906,7 +906,7 @@ def main():
             accelerator.print(f"Resuming from checkpoint {path}")
             try:
                 accelerator.load_state(args.resume_from_checkpoint)
-            except:
+            except Exception:
                 accelerator.load_state(os.path.join(args.output_dir, path))
             global_step = int(path.split("-")[1])
 

--- a/textdiffuser-2/inference_textdiffuser2_t2i_full.py
+++ b/textdiffuser-2/inference_textdiffuser2_t2i_full.py
@@ -582,7 +582,7 @@ def main():
             try:
                 ocr_ids = tokenizer.encode(ocr_ids)
                 prompt = caption_ids + ocr_ids
-            except:
+            except Exception:
                 prompt = caption_ids
 
             prompt = prompt[:args.max_length]

--- a/textdiffuser-2/inference_textdiffuser2_t2i_lora.py
+++ b/textdiffuser-2/inference_textdiffuser2_t2i_lora.py
@@ -560,7 +560,7 @@ def main():
             try:
                 ocr_ids = tokenizer.encode(ocr_ids)
                 prompt = caption_ids + ocr_ids
-            except:
+            except Exception:
                 prompt = caption_ids
 
             prompt = prompt[:args.max_length]

--- a/textdiffuser-2/predict.py
+++ b/textdiffuser-2/predict.py
@@ -261,7 +261,7 @@ class Predictor(BasePredictor):
                 try:
                     ocr_ids = self.tokenizer.encode(ocr_ids)
                     prompt = caption_ids + ocr_ids
-                except:
+                except Exception:
                     prompt = caption_ids
 
                 user_prompt = self.tokenizer.decode(prompt)

--- a/textdiffuser-2/train_textdiffuser2_inpainting_full.py
+++ b/textdiffuser-2/train_textdiffuser2_inpainting_full.py
@@ -808,7 +808,7 @@ def main():
 
             try:
                 caption = open(f'{args.dataset_path}/{first}/{second}/caption.txt').readlines()[0]
-            except:
+            except Exception:
                 caption = 'null'
                 print('erorr of caption')
             caption_ids = tokenizer(

--- a/textdiffuser-2/train_textdiffuser2_t2i_full.py
+++ b/textdiffuser-2/train_textdiffuser2_t2i_full.py
@@ -711,7 +711,7 @@ def main():
             #### get caption
             try: #### note that few cases do not contain valid captions
                 caption = open(f'{args.dataset_path}/{first}/{second}/caption.txt').readlines()[0]
-            except:
+            except Exception:
                 caption = 'null'
                 print('erorr of caption')
             
@@ -915,7 +915,7 @@ def main():
             accelerator.print(f"Resuming from checkpoint {path}")
             try:
                 accelerator.load_state(args.resume_from_checkpoint)
-            except:
+            except Exception:
                 accelerator.load_state(os.path.join(args.output_dir, path))
             global_step = int(path.split("-")[1])
 

--- a/textdiffuser-2/train_textdiffuser2_t2i_lora.py
+++ b/textdiffuser-2/train_textdiffuser2_t2i_lora.py
@@ -748,7 +748,7 @@ def main():
             #### get caption
             try: #### note that few cases do not contain valid captions
                 caption = open(f'{args.dataset_path}/{first}/{second}/caption.txt').readlines()[0]
-            except:
+            except Exception:
                 caption = 'null'
                 print('erorr of caption')
             

--- a/textdiffuser/train.py
+++ b/textdiffuser/train.py
@@ -634,7 +634,7 @@ def main():
             first, second = caption.split('_')
             try:
                 caption = open(f'{args.dataset_path}/{first}/{second}/caption.txt').readlines()[0]
-            except:
+            except Exception:
                 caption = 'null'
                 print('erorr of caption')
                 

--- a/trocr/data_aug.py
+++ b/trocr/data_aug.py
@@ -116,13 +116,13 @@ class Underline(torch.nn.Module):
             y1 = max(black_pixels[0])
             x0 = min(black_pixels[1])
             x1 = max(black_pixels[1])
-        except:
+        except Exception:
             return img
         for x in range(x0, x1):
             for y in range(y1, y1-3, -1):
                 try:
                     img.putpixel((x, y), (0, 0, 0))
-                except:
+                except Exception:
                     continue
         return img
 

--- a/trocr/task.py
+++ b/trocr/task.py
@@ -180,7 +180,7 @@ class TextRecognitionTask(LegacyFairseqTask):
         )
         try:
             from .generator import TextRecognitionGenerator
-        except:
+        except Exception:
             from generator import TextRecognitionGenerator
 
         try:

--- a/trocr/trocr_models.py
+++ b/trocr/trocr_models.py
@@ -28,7 +28,7 @@ from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 
 try:
     from .unilm_models import UniLMDecoder
-except:
+except Exception:
     from unilm_models import UniLMDecoder
 
 @register_model('DeiT_TR')

--- a/vlmo/vlmo/datasets/nlvr2_dataset.py
+++ b/vlmo/vlmo/datasets/nlvr2_dataset.py
@@ -31,7 +31,7 @@ class NLVR2Dataset(BaseDataset):
                 image_tensor_1 = self.get_image(index, image_key="image_1")["image"]
                 text = self.get_text(index)["text"]
                 result = True
-            except:
+            except Exception:
                 print(
                     f"error while read file idx {index} in {self.names[0]}",
                     file=sys.stderr,

--- a/xdoc/fine_tuning/websrc/trainer.py
+++ b/xdoc/fine_tuning/websrc/trainer.py
@@ -50,7 +50,7 @@ def train(args, dataset_web, model, tokenizer):
     try:
         from azureml.core.run import Run
         aml_run = Run.get_context()
-    except:
+    except Exception:
         aml_run = None
         
     # Open tensorboard

--- a/xdoc/fine_tuning/websrc/websrc.py
+++ b/xdoc/fine_tuning/websrc/websrc.py
@@ -151,7 +151,7 @@ class StrucDataset(Dataset):
                     try:
                         xx = node_pairs_lengths[x_tid4nid]
                         # x_tid4nid in valid tid list, or == -1
-                    except:
+                    except Exception:
                         # x_tid4nid out of bound, like `question`, `sep` or `cls`
                         xx = node_pairs_lengths[-1]
                         x_tid4nid=-1
@@ -159,7 +159,7 @@ class StrucDataset(Dataset):
                     try:
                         dis = xx[x_tid4anid]
                         # x_tid4anid in valid tid list, or == -1
-                    except:
+                    except Exception:
                         # x_tid4nid out of bound, like `question`, `sep` or `cls`
                         dis = xx[-1]
                         x_tid4anid = -1

--- a/xtune/src/run_cls.py
+++ b/xtune/src/run_cls.py
@@ -183,7 +183,7 @@ class NoisedDataGenerator(object):
                 line = line.strip()
                 try:
                     src, tgt = line.split("\t")
-                except:
+                except Exception:
                     src, tgt = line.split(" ")
                 if src not in self.lang2dict[lang]:
                     self.lang2dict[lang][src] = [tgt]

--- a/xtune/src/run_tag.py
+++ b/xtune/src/run_tag.py
@@ -185,7 +185,7 @@ class NoisedDataGenerator(object):
                 line = line.strip()
                 try:
                     src, tgt = line.split("\t")
-                except:
+                except Exception:
                     src, tgt = line.split(" ")
                 if src not in self.lang2dict[lang]:
                     self.lang2dict[lang][src] = [tgt]

--- a/xtune/src/tools/get_eval_results.py
+++ b/xtune/src/tools/get_eval_results.py
@@ -240,7 +240,7 @@ if __name__ == "__main__":
                 print(final_output[:-1])
                 pass
             all_res_terms.append(res_terms)
-        except:
+        except Exception:
             print()
             pass
 


### PR DESCRIPTION
## What
Replace 239 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.