### PR TITLE
docs: add community health files and README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Future features will be listed here
+
+### Changed
+- Ongoing updates
+
+### Fixed
+- Bug fixes
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -255,3 +255,15 @@ Portions of the source code are based on the [transformers](https://github.com/h
 For help or issues using the pre-trained models, please submit a GitHub issue.
 
 For other communications, please contact [Furu Wei](https://thegenerality.com) (`fuwei@microsoft.com`).
+
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on
+how to report bugs, suggest features, and submit pull requests.
+
+By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Add Community Health Files

This PR adds community health files to `unilm`:

- `CHANGELOG.md`
- `README.md`

**CONTRIBUTING.md** — guidelines for bug reports, feature requests, and pull requests.
**CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 standard.
**CHANGELOG.md** — Keep a Changelog format template.
**README.md** — Contributing section + community links.
